### PR TITLE
feature: phase 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,12 +74,17 @@ services:
       - backend
 
   # TTS (Kokoro-FastAPI) ──────────────────────────────────────────
-  # GPU host (NVIDIA): uses the image below as-is.
-  # CPU-only host:     replace image tag with ghcr.io/remsky/kokoro-fastapi-cpu:latest
-  #                    and remove the entire 'deploy' block.
+  # Builds a custom image that upgrades PyTorch to 2.7+ (cu128), adding support
+  # for Blackwell GPUs (RTX 5000 series, sm_120) while remaining compatible with
+  # all previous NVIDIA architectures (sm_50+).
+  # CPU-only host: replace 'build' with image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+  #                and remove the entire 'deploy' block.
+  # See: https://github.com/remsky/Kokoro-FastAPI/issues/443
   # Enable: set TTS_ENABLED=true in .env
   kokoro:
-    image: ghcr.io/remsky/kokoro-fastapi-gpu:latest
+    build:
+      context: .
+      dockerfile: docker/kokoro.Dockerfile
     restart: unless-stopped
     ports:
       - "8880:8880"

--- a/docker/kokoro.Dockerfile
+++ b/docker/kokoro.Dockerfile
@@ -1,0 +1,10 @@
+# Custom Kokoro-FastAPI for Blackwell GPUs (RTX 5000 series, sm_120)
+# The upstream image ships PyTorch <= 2.5 which only supports up to sm_90.
+# This layer upgrades torch/torchaudio to 2.7+ cu128 wheels, adding sm_120
+# support while remaining compatible with all previous NVIDIA architectures.
+# See: https://github.com/remsky/Kokoro-FastAPI/issues/443
+FROM ghcr.io/remsky/kokoro-fastapi-gpu:latest
+
+RUN /app/.venv/bin/pip install --upgrade --no-cache-dir \
+    torch torchaudio \
+    --index-url https://download.pytorch.org/whl/cu128


### PR DESCRIPTION
This pull request updates the deployment process for the Kokoro-FastAPI TTS service to add support for the latest Blackwell GPUs (RTX 5000 series, sm_120) by building a custom Docker image that upgrades PyTorch to version 2.7+ with CUDA 12.8 support. This ensures compatibility with both new and older NVIDIA GPU architectures.

**GPU Support and Docker Image Updates:**

* Modified `docker-compose.yml` to build a custom Kokoro-FastAPI image using a new `docker/kokoro.Dockerfile`, replacing the previous use of the upstream image, to enable support for Blackwell GPUs and maintain compatibility with older NVIDIA architectures.
* Added `docker/kokoro.Dockerfile`, which upgrades `torch` and `torchaudio` to version 2.7+ with CUDA 12.8, ensuring support for sm_120 (Blackwell) and all previous NVIDIA architectures.