### PR TITLE
feature: deploy to main

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,12 +74,17 @@ services:
       - backend
 
   # TTS (Kokoro-FastAPI) ──────────────────────────────────────────
-  # GPU host (NVIDIA): uses the image below as-is.
-  # CPU-only host:     replace image tag with ghcr.io/remsky/kokoro-fastapi-cpu:latest
-  #                    and remove the entire 'deploy' block.
+  # Builds a custom image that upgrades PyTorch to 2.7+ (cu128), adding support
+  # for Blackwell GPUs (RTX 5000 series, sm_120) while remaining compatible with
+  # all previous NVIDIA architectures (sm_50+).
+  # CPU-only host: replace 'build' with image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+  #                and remove the entire 'deploy' block.
+  # See: https://github.com/remsky/Kokoro-FastAPI/issues/443
   # Enable: set TTS_ENABLED=true in .env
   kokoro:
-    image: ghcr.io/remsky/kokoro-fastapi-gpu:latest
+    build:
+      context: .
+      dockerfile: docker/kokoro.Dockerfile
     restart: unless-stopped
     ports:
       - "8880:8880"

--- a/docker/kokoro.Dockerfile
+++ b/docker/kokoro.Dockerfile
@@ -1,0 +1,10 @@
+# Custom Kokoro-FastAPI for Blackwell GPUs (RTX 5000 series, sm_120)
+# The upstream image ships PyTorch <= 2.5 which only supports up to sm_90.
+# This layer upgrades torch/torchaudio to 2.7+ cu128 wheels, adding sm_120
+# support while remaining compatible with all previous NVIDIA architectures.
+# See: https://github.com/remsky/Kokoro-FastAPI/issues/443
+FROM ghcr.io/remsky/kokoro-fastapi-gpu:latest
+
+RUN /app/.venv/bin/pip install --upgrade --no-cache-dir \
+    torch torchaudio \
+    --index-url https://download.pytorch.org/whl/cu128


### PR DESCRIPTION
This pull request updates the deployment of the Kokoro-FastAPI TTS service to ensure compatibility with the latest Blackwell GPUs (RTX 5000 series, sm_120) by building a custom Docker image that upgrades PyTorch and torchaudio. The changes also preserve compatibility with all previous NVIDIA GPU architectures.

**GPU support and Docker image customization:**

* Updated the `docker-compose.yml` configuration for the `kokoro` service to build a custom Docker image using `docker/kokoro.Dockerfile` instead of pulling the default image, enabling support for Blackwell GPUs by upgrading PyTorch to version 2.7+ (cu128).
* Added a new `docker/kokoro.Dockerfile` that builds on the upstream image and upgrades `torch` and `torchaudio` to 2.7+ with CUDA 12.8 support, ensuring compatibility with sm_120 and all previous NVIDIA architectures.