### PR TITLE
feature: phase 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-05-02
+
+### Added
+- TTS (Kokoro-FastAPI) integration: `AudioPlayer` component reads flashcard words, lesson exercise sentences, correct answers, and tutor chat responses aloud
+- STT (faster-whisper) integration: `VoiceRecorder` component allows dictating answers in flashcards and lesson exercises
+- `POST /api/tts` backend proxy to Kokoro-FastAPI service (returns `audio/mpeg`)
+- `POST /api/stt` backend proxy to faster-whisper service (returns transcription text)
+- `TTS_ENABLED` and `STT_ENABLED` feature flags in `.env` — both services are disabled by default
+- Kokoro and Whisper services defined in `docker-compose.yml` with NVIDIA GPU `deploy` block
+- Custom `docker/kokoro.Dockerfile` upgrading PyTorch to 2.7+ (cu128) for Blackwell GPU support (RTX 5000 series, sm_120), compatible with all previous NVIDIA architectures (sm_50+)
+- `docker-compose.yml` updated to use fork image `ghcr.io/artcc/kokoro-fastapi-gpu` with full Blackwell support
+- `AudioPlayer` added to tutor chat messages — button appears after streaming completes
+
+### Fixed
+- Kokoro container crash on NVIDIA Blackwell GPUs (`CUDA error: no kernel image is available`) caused by PyTorch ≤ 2.5 lacking sm_120 support
+
 ## [1.0.0] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ the frontend never calls them directly.
 freelingo/
 ├── assets/             # Logos and static assets
 ├── backend/            # FastAPI (Python)
+├── docker/             # Custom Dockerfiles (e.g. Kokoro with Blackwell GPU support)
+├── docs/               # GitHub Pages landing site
 ├── frontend/           # Next.js (React)
 ├── messages/           # i18n translation files (en, es, fr, pt, de, it)
 ├── specs/              # Specification files
@@ -70,7 +72,7 @@ freelingo/
 |-------|------------------------|----------------|
 | 1     | Learning platform      | ✅ Complete    |
 | 1+    | Learning Resources Hub | ✅ Complete    |
-| 2     | Local TTS + STT        | 🚧 In Progress |
+| 2     | Local TTS + STT        | ✅ Complete    |
 | 3     | Real-time conversation | ⏳ Planned     |
 
 ## Quick start
@@ -140,13 +142,14 @@ TTS (Kokoro) and STT (faster-whisper) are disabled by default. Both services are
 
 ### GPU host (NVIDIA)
 
-1. Uncomment the `kokoro` and `whisper` services in `docker-compose.yml` (they are already configured with `deploy.resources.reservations.devices` for NVIDIA).
-2. Add to `.env`:
+1. The `kokoro` and `whisper` services are already configured in `docker-compose.yml` with the NVIDIA `deploy` block.
+2. The Kokoro image (`ghcr.io/artcc/kokoro-fastapi-gpu`) ships with PyTorch 2.7+ (cu128), supporting all NVIDIA architectures including **Blackwell (RTX 5000 series, sm_120)**.
+3. Add to `.env`:
    ```env
    TTS_ENABLED=true
    STT_ENABLED=true
    ```
-3. Restart the stack: `docker compose up -d`.
+4. Restart the stack: `docker compose up -d`.
 
 ### CPU-only host
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,10 +81,9 @@ services:
   # See: https://github.com/ArtCC/Kokoro-FastAPI
   # Enable: set TTS_ENABLED=true in .env
   kokoro:
-    image: ghcr.io/artcc/kokoro-fastapi-gpu:latest
+    image: ghcr.io/artcc/kokoro-fastapi-gpu:v0.2.4-master
+    container_name: kokoro
     restart: unless-stopped
-    ports:
-      - "8880:8880"
     environment:
       - PYTHONUNBUFFERED=1
     deploy:
@@ -102,9 +101,8 @@ services:
   # Enable: set STT_ENABLED=true in .env
   whisper:
     image: onerahmet/openai-whisper-asr-webservice:latest-gpu
+    container_name: whisper
     restart: unless-stopped
-    ports:
-      - "9000:9000"
     environment:
       - ASR_MODEL=medium
       - ASR_ENGINE=faster_whisper

--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { apiFetch } from '@/lib/api'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { AudioPlayer } from '@/components/ui/AudioPlayer'
 
 interface Message {
   role: 'user' | 'assistant'
@@ -261,6 +262,11 @@ export default function ChatPage() {
                       : null
                     )}
                   </div>
+                  {msg.role === 'assistant' && msg.content && !(sending && i === messages.length - 1) && (
+                    <div className="mt-1">
+                      <AudioPlayer text={msg.content} size="sm" />
+                    </div>
+                  )}
                 </div>
               </div>
             ))


### PR DESCRIPTION
This pull request introduces full local TTS (Text-to-Speech) and STT (Speech-to-Text) support, enabling users to listen to flashcards, exercises, and chat responses, as well as dictate answers. It adds backend proxies, frontend components, and Docker improvements for GPU support, especially for NVIDIA Blackwell GPUs. The documentation and changelog are updated to reflect these enhancements.

**TTS/STT Feature Integration:**
* Added `AudioPlayer` to tutor chat messages so users can listen to assistant responses after streaming completes (`frontend/src/app/(app)/chat/page.tsx`, `frontend/src/app/(app)/chat/page.tsx`, `frontend/src/app/(app)/chat/page.tsx`) [[1]](diffhunk://#diff-36785259041e3f350d8b3e8c9ed96b91bffe889d68b78b36e6aad5096478a8a7R7) [[2]](diffhunk://#diff-36785259041e3f350d8b3e8c9ed96b91bffe889d68b78b36e6aad5096478a8a7R265-R269)
* Integrated TTS (Kokoro-FastAPI) and STT (faster-whisper) features, including backend proxy endpoints (`POST /api/tts`, `POST /api/stt`) and new feature flags (`TTS_ENABLED`, `STT_ENABLED`) in `.env`

**Docker & GPU Support:**
* Updated `docker-compose.yml` to use a custom Kokoro image (`ghcr.io/artcc/kokoro-fastapi-gpu:v0.2.4-master`) with PyTorch 2.7+ (cu128) for Blackwell GPU compatibility; added `container_name` fields for clarity [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L84-L87) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R104-L107)
* Added custom Dockerfile for Kokoro and clarified GPU requirements and setup in documentation [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R43) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R152)

**Documentation & Changelog:**
* Updated `CHANGELOG.md` for v1.1.0 with detailed TTS/STT additions, bug fixes for Blackwell GPU support, and new Docker images
* Marked TTS/STT milestone as complete and improved project structure documentation in `README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R43)