### PR TITLE
feature: deploy to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,4 +49,4 @@ TTS_VOICE=af_heart
 # STT
 STT_ENABLED=true
 STT_BASE_URL=http://whisper:9000
-STT_MODEL=medium
+STT_MODEL=tiny.en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-02
+
+### Added
+- Theme mode selector in Settings: three explicit options — Auto (system), Dark, Light — replacing the previous toggle; Auto is the default and follows the OS `prefers-color-scheme` preference in real time
+
+### Fixed
+- Chat tutor system prompt: added instruction to never use emojis or emoticons (TTS reads them aloud)
+- Chat sidebar on mobile and narrow viewports: sidebar now hidden by default on screens below `md` breakpoint; opens as a fixed overlay with a semi-transparent backdrop instead of a side-by-side column, preventing the chat area from becoming unusably narrow
+
 ## [1.1.0] - 2026-05-02
 
 ### Added

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -49,6 +49,7 @@ Guidelines:
 - You may briefly explain corrections in {native_language} if it helps clarity,
   but always keep the main conversation in English
 - Keep responses concise (2–4 sentences unless explaining grammar)
+- Do not use emojis or emoticons in your responses
 """
 
 MAX_HISTORY = 30

--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -29,7 +29,7 @@ export default function ChatPage() {
   const [error, setError] = useState('')
   const [loadingConvs, setLoadingConvs] = useState(true)
   const [loadingMsgs, setLoadingMsgs] = useState(false)
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
   const [deletePending, setDeletePending] = useState<number | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -39,6 +39,11 @@ export default function ChatPage() {
   }, [])
 
   useEffect(() => { scrollBottom() }, [messages, scrollBottom])
+
+  // Open sidebar by default only on desktop
+  useEffect(() => {
+    setSidebarOpen(window.innerWidth >= 768)
+  }, [])
 
   const loadConversations = useCallback(async () => {
     try {
@@ -168,9 +173,17 @@ export default function ChatPage() {
   return (
     <div className="flex w-full h-[calc(100dvh-56px)] md:h-screen overflow-hidden">
 
+      {/* Sidebar backdrop — mobile only */}
+      {sidebarOpen && (
+        <div
+          className="md:hidden fixed top-14 inset-x-0 bottom-0 z-10 bg-black/40"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
       {/* Sidebar */}
       {sidebarOpen && (
-        <aside className="w-56 shrink-0 flex flex-col border-r border-fl-border bg-fl-bg overflow-hidden">
+        <aside className="fixed top-14 bottom-0 left-0 z-20 w-56 md:relative md:top-auto md:bottom-auto md:left-auto md:z-auto shrink-0 flex flex-col border-r border-fl-border bg-fl-bg overflow-hidden">
           <div className="flex items-center justify-between px-4 py-3 border-b border-fl-border">
             <span className="font-mono text-fl-hint tracking-widest text-fl-muted-2 uppercase">{t('conversations')}</span>
             <button

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -24,7 +24,7 @@ export default function SettingsPage() {
   const logout = useAuthStore((s) => s.logout)
   const router = useRouter()
   const theme = useThemeStore((s) => s.theme)
-  const toggleTheme = useThemeStore((s) => s.toggle)
+  const setTheme = useThemeStore((s) => s.setTheme)
 
   const [displayName, setDisplayName] = useState('')
   const [email, setEmail] = useState('')
@@ -196,24 +196,33 @@ export default function SettingsPage() {
         — {tCommon('logout')}
       </button>
 
-      {/* Theme toggle */}
+      {/* Theme */}
       <div className="border border-fl-border bg-fl-surface p-6">
         <div className="flex items-center gap-2 pb-4 mb-5 border-b border-fl-border">
           <span className="text-fl-label text-fl-muted-2">●</span>
           <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">{t('sectionAppearance')}</span>
         </div>
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-4">
           <div>
             <p className="font-mono text-xs text-fl-fg tracking-wide">{t('theme')}</p>
-            <p className="font-mono text-fl-label text-fl-muted-2 mt-0.5">{theme === 'dark' ? t('darkActive') : t('lightActive')}</p>
+            <p className="font-mono text-fl-label text-fl-muted-2 mt-0.5">
+              {theme === 'dark' ? t('darkActive') : theme === 'light' ? t('lightActive') : t('systemActive')}
+            </p>
           </div>
-          <button
-            onClick={toggleTheme}
-            className="flex items-center gap-3 border border-fl-border px-4 py-2 font-mono text-fl-label tracking-widest uppercase text-fl-muted-2 hover:border-fl-border-2 hover:text-fl-fg transition-colors"
-          >
-            <span>{theme === 'dark' ? '○' : '●'}</span>
-            {theme === 'dark' ? t('switchToLight') : t('switchToDark')}
-          </button>
+          <div className="flex gap-1">
+            {(['system', 'dark', 'light'] as const).map((opt) => (
+              <button
+                key={opt}
+                onClick={() => setTheme(opt)}
+                className={`border px-3 py-2 font-mono text-fl-label tracking-widest uppercase transition-colors ${theme === opt
+                    ? 'border-fl-border-2 text-fl-fg bg-fl-surface-2'
+                    : 'border-fl-border text-fl-muted-2 hover:border-fl-border-2 hover:text-fl-fg'
+                  }`}
+              >
+                {opt === 'system' ? t('themeSystem') : opt === 'dark' ? t('themeDark') : t('themeLight')}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ThemeProvider.tsx
+++ b/frontend/src/components/ThemeProvider.tsx
@@ -3,16 +3,32 @@
 import { useEffect } from 'react'
 import { useThemeStore } from '@/store/theme'
 
+function applyTheme(theme: 'dark' | 'light') {
+  const html = document.documentElement
+  if (theme === 'light') {
+    html.setAttribute('data-theme', 'light')
+  } else {
+    html.removeAttribute('data-theme')
+  }
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const theme = useThemeStore((s) => s.theme)
 
   useEffect(() => {
-    const html = document.documentElement
-    if (theme === 'light') {
-      html.setAttribute('data-theme', 'light')
-    } else {
-      html.removeAttribute('data-theme')
+    if (theme !== 'system') {
+      applyTheme(theme)
+      return
     }
+
+    // System: follow OS preference
+    const mq = window.matchMedia('(prefers-color-scheme: light)')
+    const handler = (e: MediaQueryListEvent | MediaQueryList) => {
+      applyTheme(e.matches ? 'light' : 'dark')
+    }
+    handler(mq)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
   }, [theme])
 
   return <>{children}</>

--- a/frontend/src/store/theme.ts
+++ b/frontend/src/store/theme.ts
@@ -1,20 +1,18 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-type Theme = 'dark' | 'light'
+export type Theme = 'system' | 'dark' | 'light'
 
 interface ThemeStore {
   theme: Theme
   setTheme: (theme: Theme) => void
-  toggle: () => void
 }
 
 export const useThemeStore = create<ThemeStore>()(
   persist(
-    (set, get) => ({
-      theme: 'dark',
+    (set) => ({
+      theme: 'system',
       setTheme: (theme) => set({ theme }),
-      toggle: () => set({ theme: get().theme === 'dark' ? 'light' : 'dark' }),
     }),
     { name: 'fl-theme' }
   )

--- a/messages/de.json
+++ b/messages/de.json
@@ -107,6 +107,10 @@
     "theme": "Thema",
     "darkActive": "Dunkelmodus aktiv",
     "lightActive": "Hellmodus aktiv",
+    "systemActive": "Automatisch (System)",
+    "themeSystem": "Auto",
+    "themeDark": "Dunkel",
+    "themeLight": "Hell",
     "switchToLight": "Zu Hell wechseln",
     "switchToDark": "Zu Dunkel wechseln"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -107,6 +107,10 @@
     "theme": "Theme",
     "darkActive": "Dark mode active",
     "lightActive": "Light mode active",
+    "systemActive": "Automatic (system)",
+    "themeSystem": "Auto",
+    "themeDark": "Dark",
+    "themeLight": "Light",
     "switchToLight": "Switch to Light",
     "switchToDark": "Switch to Dark"
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -107,6 +107,10 @@
     "theme": "Tema",
     "darkActive": "Modo oscuro activo",
     "lightActive": "Modo claro activo",
+    "systemActive": "Automático (sistema)",
+    "themeSystem": "Auto",
+    "themeDark": "Oscuro",
+    "themeLight": "Claro",
     "switchToLight": "Cambiar a claro",
     "switchToDark": "Cambiar a oscuro"
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -107,6 +107,10 @@
     "theme": "Thème",
     "darkActive": "Mode sombre actif",
     "lightActive": "Mode clair actif",
+    "systemActive": "Automatique (système)",
+    "themeSystem": "Auto",
+    "themeDark": "Sombre",
+    "themeLight": "Clair",
     "switchToLight": "Passer au clair",
     "switchToDark": "Passer au sombre"
   },

--- a/messages/it.json
+++ b/messages/it.json
@@ -107,6 +107,10 @@
     "theme": "Tema",
     "darkActive": "Modalità scura attiva",
     "lightActive": "Modalità chiara attiva",
+    "systemActive": "Automatico (sistema)",
+    "themeSystem": "Auto",
+    "themeDark": "Scuro",
+    "themeLight": "Chiaro",
     "switchToLight": "Passa al chiaro",
     "switchToDark": "Passa allo scuro"
   },

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -107,6 +107,10 @@
     "theme": "Tema",
     "darkActive": "Modo escuro ativo",
     "lightActive": "Modo claro ativo",
+    "systemActive": "Automático (sistema)",
+    "themeSystem": "Auto",
+    "themeDark": "Escuro",
+    "themeLight": "Claro",
     "switchToLight": "Mudar para claro",
     "switchToDark": "Mudar para escuro"
   },


### PR DESCRIPTION
This pull request introduces several improvements to the user interface and experience, particularly around theme selection and mobile usability, as well as a minor backend configuration update. The most notable changes are the introduction of a new theme mode selector with an "Auto" (system) option, enhancements to the chat sidebar behavior on mobile devices, and an update to the chat tutor system prompt to avoid emojis and emoticons.

**User Interface and Experience Improvements:**

* Added a theme mode selector in the Settings page with three explicit options: Auto (system), Dark, and Light. The "Auto" option follows the OS `prefers-color-scheme` preference in real time and is now the default. The toggle has been replaced with explicit buttons, and supporting translations were added for all supported languages. (`frontend/src/app/(app)/settings/page.tsx`, `frontend/src/components/ThemeProvider.tsx`, `frontend/src/store/theme.ts`, `messages/en.json`, `messages/de.json`, `messages/es.json`, `messages/fr.json`, `messages/it.json`, `messages/pt.json`) [[1]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0L199-R225) [[2]](diffhunk://#diff-12893cadd7c115320cb23865cc41ea247b445d2c0bc650456577dcabf4d65726L6-R31) [[3]](diffhunk://#diff-603013fc1ae862a4ad9aacc14d47756416627601240e14cb5f62aba1d3886b17L4-L17) [[4]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeR110-R113) [[5]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158R110-R113) [[6]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2R110-R113) [[7]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877R110-R113) [[8]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778R110-R113) [[9]](diffhunk://#diff-e7f6219511cfdbf367e656ee21bf93dba648011492721e6ab7d416bdb25fae43R110-R113)
* Improved chat sidebar behavior on mobile and narrow viewports: the sidebar is now hidden by default on screens below the `md` breakpoint and opens as a fixed overlay with a semi-transparent backdrop, preventing the chat area from becoming unusably narrow. (`frontend/src/app/(app)/chat/page.tsx`) [[1]](diffhunk://#diff-36785259041e3f350d8b3e8c9ed96b91bffe889d68b78b36e6aad5096478a8a7L32-R32) [[2]](diffhunk://#diff-36785259041e3f350d8b3e8c9ed96b91bffe889d68b78b36e6aad5096478a8a7R43-R47) [[3]](diffhunk://#diff-36785259041e3f350d8b3e8c9ed96b91bffe889d68b78b36e6aad5096478a8a7R176-R186)

**Backend and Prompt Updates:**

* Updated the chat tutor system prompt to instruct the AI not to use emojis or emoticons in responses, as TTS reads them aloud. (`backend/app/routers/chat.py`)

**Configuration Changes:**

* Changed the default speech-to-text model in `.env.example` from `medium` to `tiny.en` for improved performance or resource usage. (`.env.example`)

**Documentation:**

* Updated `CHANGELOG.md` to document these changes under version 1.1.1.