### PR TITLE
feature: deploy to main

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -37,6 +37,17 @@ const nextConfig: NextConfig = {
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(self), geolocation=()' },
         ],
       },
+      {
+        // SharedArrayBuffer is required by onnxruntime-web threaded WASM.
+        // Firefox blocks it without cross-origin isolation (COOP + COEP).
+        // 'credentialless' COEP allows cross-origin resources without CORP headers
+        // while still enabling SharedArrayBuffer (Firefox 119+, Chrome 96+).
+        source: '/conversation',
+        headers: [
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
+        ],
+      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
This pull request adds new HTTP security headers to the `/conversation` route in the Next.js configuration to support the use of `SharedArrayBuffer` in browsers. This is necessary for enabling onnxruntime-web's threaded WASM, and ensures compatibility with modern versions of Firefox and Chrome.

**Security and browser compatibility improvements:**

* Added `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless` headers to the `/conversation` route in `next.config.ts` to enable `SharedArrayBuffer` usage for onnxruntime-web threaded WASM, improving cross-browser support.