### PR TITLE
feature: deploy to main

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -35,15 +35,9 @@ const nextConfig: NextConfig = {
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(self), geolocation=()' },
-        ],
-      },
-      {
-        // SharedArrayBuffer is required by onnxruntime-web threaded WASM.
-        // Firefox blocks it without cross-origin isolation (COOP + COEP).
-        // 'credentialless' COEP allows cross-origin resources without CORP headers
-        // while still enabling SharedArrayBuffer (Firefox 119+, Chrome 96+).
-        source: '/conversation',
-        headers: [
+          // Required for SharedArrayBuffer (onnxruntime-web threaded WASM).
+          // credentialless COEP is more permissive than require-corp and works
+          // with client-side navigation in Next.js (headers must be global).
           { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
           { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
         ],

--- a/frontend/src/components/conversation/ConversationMode.tsx
+++ b/frontend/src/components/conversation/ConversationMode.tsx
@@ -75,11 +75,10 @@ export default function ConversationMode() {
   useEffect(() => {
     if (vad.loading) return
     if (vad.errored) {
-      const err = vad.errored as { name?: string; message?: string }
+      const errMsg = typeof vad.errored === 'string' ? vad.errored : ''
       const isPermission =
-        err?.name === 'NotAllowedError' || err?.name === 'PermissionDeniedError'
-      const detail = err?.message ? ` — ${err.message}` : err?.name ? ` — ${err.name}` : ''
-      setErrorMsg(isPermission ? t('errorMic') : `${t('errorVadInit')}${detail}`)
+        errMsg.includes('NotAllowedError') || errMsg.includes('PermissionDeniedError')
+      setErrorMsg(isPermission ? t('errorMic') : `${t('errorVadInit')}${errMsg ? ` — ${errMsg}` : ''}`)
       setStatus('error')
       return
     }


### PR DESCRIPTION
- Remove per-route COOP and COEP headers and consolidate them as global headers in next.config.ts
- Update COEP header to use 'credentialless' for SharedArrayBuffer support with onnxruntime-web
- Modify ConversationMode component to handle vad.errored as a string and adjust error message construction
- Detect permission errors by checking error message content instead of error name property