### PR TITLE
feature: deploy to main

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,9 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY frontend/ .
 COPY messages/ ./messages/
+# Re-run postinstall to ensure all ORT WASM + .mjs loaders are present in public/vad/
+# (deps stage generates them but COPY frontend/ . above overwrites public/vad from source)
+RUN node scripts/copy-vad-models.js
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 


### PR DESCRIPTION
This pull request makes a small but important change to the frontend Docker build process. It ensures that all required WASM and `.mjs` loader files for ORT (Onnx Runtime) are present in the `public/vad/` directory after the frontend files are copied, preventing them from being accidentally overwritten.

Build process fix:

* Added a `RUN node scripts/copy-vad-models.js` step in the `frontend/Dockerfile` to re-copy ORT WASM and `.mjs` loader files into `public/vad/` after the frontend source is copied, ensuring these files are not lost during the build process.