### PR TITLE
feature: deploy to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,10 @@ TTS_VOICE=af_heart
 STT_ENABLED=true
 STT_BASE_URL=http://whisper:9000
 STT_MODEL=tiny.en
+
+# Frontend
+# Public URL of the backend as seen by the browser (used for WebSocket connections).
+# Next.js rewrites only handle HTTP — the WS must connect directly to the backend.
+# Set to your public HTTPS backend URL, e.g. https://freelingo.example.com
+# Leave empty only if both frontend and backend share the exact same public hostname.
+NEXT_PUBLIC_API_URL=https://freelingo.example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,10 @@ services:
     restart: unless-stopped
     environment:
       BACKEND_URL: http://backend:8000
+      # Public URL the browser uses to open the WebSocket connection.
+      # Next.js rewrites only work for HTTP — WS must connect directly.
+      # Set this to the public HTTPS URL of your backend API.
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
     ports:
       - "3000:3000"
     depends_on:

--- a/frontend/src/components/conversation/ConversationMode.tsx
+++ b/frontend/src/components/conversation/ConversationMode.tsx
@@ -171,7 +171,7 @@ export default function ConversationMode() {
 
       ws.onerror = () => {
         if (!cleanEndRef.current) {
-          setErrorMsg(t('errorConnection'))
+          setErrorMsg(`${t('errorConnection')} [onerror → ${url}]`)
           setStatus('error')
           setSessionActive(false)
         }
@@ -182,7 +182,7 @@ export default function ConversationMode() {
           if (ev.code === 1008) {
             setErrorMsg(t('errorUnauthorized'))
           } else if (ev.code !== 1000) {
-            setErrorMsg(t('errorConnection'))
+            setErrorMsg(`${t('errorConnection')} [code ${ev.code}: ${ev.reason || 'no reason'} → ${url}]`)
           }
           setStatus('error')
           setSessionActive(false)


### PR DESCRIPTION
This pull request introduces improvements to WebSocket connection configuration and error reporting, making deployment and debugging easier. The main changes are the addition of a new environment variable for specifying the public API URL, its integration into the Docker setup, and enhanced error messages in the conversation component.

**Configuration improvements:**

* Added a new `NEXT_PUBLIC_API_URL` environment variable to `.env.example` for specifying the public HTTPS backend URL, which is necessary for WebSocket connections from the frontend.
* Updated `docker-compose.yml` to pass the `NEXT_PUBLIC_API_URL` environment variable to the frontend service, ensuring the frontend can connect to the correct backend endpoint for WebSockets.

**Error reporting enhancements:**

* Improved WebSocket error messages in `ConversationMode.tsx` to include the URL, error code, and reason, making debugging easier when connection issues occur. [[1]](diffhunk://#diff-9f45dafa806858587eede8733af8eb8b66be90644255fc99fd69f918dc4431caL174-R174) [[2]](diffhunk://#diff-9f45dafa806858587eede8733af8eb8b66be90644255fc99fd69f918dc4431caL185-R185)