### PR TITLE
feature: deploy to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ STT_MODEL=tiny.en
 # Frontend
 # Public URL of the backend as seen by the browser (used for WebSocket connections).
 # Next.js rewrites only handle HTTP — the WS must connect directly to the backend.
-# Set to your public HTTPS backend URL, e.g. https://freelingo.example.com
-# Leave empty only if both frontend and backend share the exact same public hostname.
-NEXT_PUBLIC_API_URL=https://freelingo.example.com
+#
+# - Same domain / path-based proxy (e.g. Nginx: /api → backend, / → frontend):
+#   leave empty — the WS will use window.location automatically.
+#
+# - Separate subdomains (e.g. Traefik with freelingo-api.example.com for backend):
+#   set to the backend's public HTTPS URL.
+#
+# This value is baked into the Docker image at build time (NEXT_PUBLIC_*).
+# Set it as a build arg / CI secret, not a runtime env var.
+NEXT_PUBLIC_API_URL=

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,5 +69,7 @@ jobs:
           push: true
           tags: ${{ steps.meta-frontend.outputs.tags }}
           labels: ${{ steps.meta-frontend.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,10 +68,6 @@ services:
     restart: unless-stopped
     environment:
       BACKEND_URL: http://backend:8000
-      # Public URL the browser uses to open the WebSocket connection.
-      # Next.js rewrites only work for HTTP — WS must connect directly.
-      # Set this to the public HTTPS URL of your backend API.
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
     ports:
       - "3000:3000"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,9 @@ RUN npm ci
 
 FROM node:20-alpine AS builder
 WORKDIR /app
+# NEXT_PUBLIC_* vars are inlined at build time — must be ARGs, not runtime envs
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 COPY --from=deps /app/node_modules ./node_modules
 COPY frontend/ .
 COPY messages/ ./messages/


### PR DESCRIPTION
This pull request updates how the `NEXT_PUBLIC_API_URL` environment variable is handled for the frontend, clarifying its usage and ensuring it is set at build time rather than runtime. The changes improve deployment flexibility and documentation for different hosting scenarios.

**Frontend environment configuration:**

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL57-R66): Expanded documentation for `NEXT_PUBLIC_API_URL`, clarifying when to leave it empty (same domain/path proxy) and when to set it (separate subdomains), and emphasizing that it should be set as a build argument rather than a runtime variable.

**Docker build and deployment:**

* [`frontend/Dockerfile`](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8R10-R12): Switched `NEXT_PUBLIC_API_URL` to a build-time `ARG` and set it as an `ENV` variable, ensuring it is baked into the Docker image during build.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R72-R73): Passed `NEXT_PUBLIC_API_URL` as a build argument from GitHub secrets during Docker image build in CI.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L71-L74): Removed `NEXT_PUBLIC_API_URL` from the runtime environment variables for the frontend service, aligning with the new approach of setting it at build time.