### PR TITLE
feature: deploy to main

### DIFF
--- a/backend/app/services/conversation_pipeline.py
+++ b/backend/app/services/conversation_pipeline.py
@@ -66,7 +66,13 @@ class ConversationPipeline:
         ]
         try:
             while True:
-                data = await ws.receive()
+                try:
+                    data = await ws.receive()
+                except RuntimeError:
+                    # Client disconnected — ws.receive() raises RuntimeError after disconnect
+                    break
+                if data.get("type") == "websocket.disconnect":
+                    break
                 if "bytes" in data:
                     await self.handle_audio(data["bytes"], ws)
                 elif "text" in data:

--- a/backend/app/services/stt_service.py
+++ b/backend/app/services/stt_service.py
@@ -3,21 +3,27 @@ import httpx
 
 class STTService:
     def __init__(self, base_url: str) -> None:
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/")
 
     async def transcribe(
         self,
         audio_bytes: bytes,
-        filename: str = "audio.webm",
-        mime_type: str = "audio/webm",
+        filename: str = "audio.wav",
+        mime_type: str = "audio/wav",
     ) -> str:
-        """Send audio to Whisper ASR and return the transcribed text."""
+        """Send audio to Whisper ASR and return the transcribed text.
+
+        Compatible with onerahmet/openai-whisper-asr-webservice which exposes
+        POST /asr?output=json&language=en (not the OpenAI /v1/audio/transcriptions path).
+        """
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{self.base_url}/v1/audio/transcriptions",
-                files={"file": (filename, audio_bytes, mime_type)},
-                data={"model": "whisper-1", "language": "en"},
+                f"{self.base_url}/asr",
+                params={"output": "json", "language": "en", "task": "transcribe"},
+                files={"audio_file": (filename, audio_bytes, mime_type)},
                 timeout=60.0,
             )
             response.raise_for_status()
-            return response.json()["text"]
+            data = response.json()
+            # Response: {"text": "...", ...}
+            return data.get("text", "").strip()


### PR DESCRIPTION
This pull request updates the speech-to-text (STT) service integration and improves the handling of websocket client disconnects. The main changes include switching the STT service to use a different API endpoint compatible with the `onerahmet/openai-whisper-asr-webservice` and making the websocket pipeline more robust against client disconnects.

**STT Service Integration:**

* Updated the `STTService` class to use the `/asr` endpoint instead of the OpenAI `/v1/audio/transcriptions` path, making it compatible with the `onerahmet/openai-whisper-asr-webservice` API. Adjusted parameters, file field names, and response parsing accordingly.
* Changed default audio filename and MIME type from `.webm`/`audio/webm` to `.wav`/`audio/wav` for consistency with the new API.
* Ensured that trailing slashes are removed from the base URL to prevent malformed requests.

**WebSocket Pipeline Robustness:**

* Improved the `ConversationPipeline.run` method to gracefully handle websocket client disconnects by catching `RuntimeError` from `ws.receive()` and checking for explicit disconnect messages.