### PR TITLE
feature: deploy to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,8 @@ TTS_VOICE=af_heart
 # STT
 STT_ENABLED=true
 STT_BASE_URL=http://whisper:9000
-STT_MODEL=tiny.en
+STT_MODEL=large-v3-turbo
+STT_ENGINE=faster_whisper
 
 # Logging
 # Levels: DEBUG, INFO, WARNING, ERROR. INFO is the recommended default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-05-02
+
+### Added
+- Structured logging across the voice conversation pipeline (`[conversation]`, `[pipeline]`, `[stt]` prefixes) at INFO / DEBUG / ERROR levels
+- `LOG_LEVEL` configuration variable (default `INFO`) in `config.py`, `docker-compose.yml`, and `.env.example`; applied via `logging.basicConfig` at startup
+- `STT_ENGINE` variable in `.env.example` and `docker-compose.yml` (`${STT_ENGINE:-faster_whisper}`) so the Whisper inference engine is configurable without editing the compose file
+- TTS voice reference table and STT model/engine reference table added to README
+
+### Changed
+- `STT_MODEL` in `docker-compose.yml` now reads from `.env` via `${STT_MODEL:-large-v3-turbo}` instead of being hardcoded
+- Default STT model upgraded from `tiny.en` / `medium` to `large-v3-turbo` — best speed/accuracy ratio on GPU (≥6 GB VRAM), ~8× faster than `large-v3` with near-identical accuracy
+- Conversation system prompt: added explicit prohibition on emojis and emoticons (same rule as chat tutor — TTS reads them aloud)
+- README "Enabling TTS & STT" notes updated to reflect that `STT_MODEL` and `STT_ENGINE` are now controlled from `.env`
+
 ## [1.2.0] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -188,8 +188,45 @@ TTS (Kokoro) and STT (faster-whisper) are disabled by default. Both services are
 ### Notes
 
 - If TTS or STT is disabled, the backend returns `503` on those endpoints. The frontend gracefully degrades: the listen/record buttons are not rendered.
-- The TTS voice can be changed via `TTS_VOICE` in `.env` (default: `af_heart`). Available voices: `af_heart`, `af_sky` (American), `bf_emma`, `bm_george` (British).
-- The STT model is controlled by `ASR_MODEL` inside the whisper container environment variable, not from `.env`.
+- The TTS voice can be changed via `TTS_VOICE` in `.env` (default: `af_heart`).
+- The STT model and engine are controlled via `.env` (`STT_MODEL` and `STT_ENGINE`).
+
+### TTS voice options (Kokoro-82M)
+
+All voices are for English. Grades reflect training data quality and quantity.
+
+| Voice | Gender | Accent | Grade |
+|-------|--------|--------|-------|
+| `af_heart` | F | American | A ⭐ |
+| `af_bella` | F | American | A- |
+| `af_nicole` | F | American | B- |
+| `am_fenrir` | M | American | C+ |
+| `am_michael` | M | American | C+ |
+| `am_puck` | M | American | C+ |
+| `bf_emma` | F | British | B- |
+| `bm_george` | M | British | C |
+
+Set with `TTS_VOICE=<voice>` in `.env`. Default: `af_heart`.
+
+### STT model options (Whisper)
+
+| Model | VRAM | Speed vs large | Notes |
+|-------|------|----------------|-------|
+| `tiny.en` | ~1 GB | ~10x | Very low accuracy |
+| `small.en` | ~2 GB | ~4x | OK for CPU |
+| `medium` | ~5 GB | ~2x | Good balance |
+| `large-v3-turbo` | ~6 GB | ~8x | **Recommended** — best speed/accuracy ratio |
+| `large-v3` | ~10 GB | 1x | Maximum accuracy |
+
+Set with `STT_MODEL=<model>` in `.env`. Default: `large-v3-turbo`.
+
+| Engine | Notes |
+|--------|-------|
+| `faster_whisper` | **Recommended** — 4× faster than openai_whisper, lower VRAM via CTranslate2 |
+| `openai_whisper` | Original PyTorch implementation |
+| `whisperx` | Adds speaker diarization; requires HuggingFace token |
+
+Set with `STT_ENGINE=<engine>` in `.env`. Default: `faster_whisper`.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,8 @@ services:
     container_name: whisper
     restart: unless-stopped
     environment:
-      - ASR_MODEL=medium
-      - ASR_ENGINE=faster_whisper
+      - ASR_MODEL=${STT_MODEL:-large-v3-turbo}
+      - ASR_ENGINE=${STT_ENGINE:-faster_whisper}
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
This pull request updates the configuration and documentation for the speech-to-text (STT) and text-to-speech (TTS) features, making the STT model and engine configurable from the `.env` file and improving clarity around available options. The default STT model is upgraded for better speed and accuracy, and detailed reference tables for TTS voices and STT models/engines are added to the documentation.

Configuration improvements:

* Made `STT_MODEL` and `STT_ENGINE` configurable via `.env` and `docker-compose.yml`, allowing users to change the Whisper model and inference engine without editing the compose file. The default STT model is now `large-v3-turbo` for better speed/accuracy, and the default engine is `faster_whisper`. (`[[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL52-R53)`, `[[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L108-R109)`)

Documentation enhancements:

* Added TTS voice and STT model/engine reference tables to `README.md`, detailing available options, recommended defaults, and configuration instructions. (`[README.mdL191-R229](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L191-R229)`)
* Updated `README.md` notes to clarify that both `STT_MODEL` and `STT_ENGINE` are now controlled from `.env`, not hardcoded in the container environment. (`[README.mdL191-R229](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L191-R229)`)
* Updated the changelog to document these configuration and documentation changes, including the new variables and improved defaults. (`[CHANGELOG.mdR8-R21](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R21)`)