### PR TITLE
feature: deploy to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ The first registered user becomes admin automatically.
 - The `LLM_PROVIDER` field controls the LLM provider: `ollama` (local, recommended), `openai`, `anthropic`, or `deepseek`.
 - The target language is always **English**. During registration, the user's native language is asked for flashcard translations and tutor feedback.
 
+## Reverse proxy requirement (real-time conversation)
+
+The real-time voice conversation feature uses a WebSocket connection (`/ws/conversation`). Next.js does not proxy WebSocket upgrades natively, so **a reverse proxy is required in any production deployment** to route `/ws/*` traffic to the backend container.
+
+This is also a hard browser requirement: `getUserMedia` (microphone access) only works in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) — HTTPS or localhost. A reverse proxy terminating TLS is therefore mandatory for the conversation feature to work at all in production.
+
+The WebSocket URL is derived automatically from `window.location`, so no extra configuration is needed on the frontend side — just ensure your reverse proxy forwards `/ws/*` to `backend:8000`.
+
 ## Enabling TTS & STT
 
 TTS (Kokoro) and STT (faster-whisper) are disabled by default at the application level, even though the services are running in Docker Compose. Enable them in `.env` to activate voice features.
@@ -161,8 +169,6 @@ TTS (Kokoro) and STT (faster-whisper) are disabled by default at the application
    kokoro:
      image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
      restart: unless-stopped
-     ports:
-       - "8880:8880"
    ```
 
    **Whisper (STT):**
@@ -170,8 +176,6 @@ TTS (Kokoro) and STT (faster-whisper) are disabled by default at the application
    whisper:
      image: onerahmet/openai-whisper-asr-webservice:latest
      restart: unless-stopped
-     ports:
-       - "9000:9000"
      environment:
        - ASR_MODEL=base
        - ASR_ENGINE=faster_whisper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,6 @@ services:
       CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}
       COOKIE_SECURE: ${COOKIE_SECURE:-false}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
-    ports:
-      - "8000:8000"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
This pull request updates documentation and Docker configuration to clarify deployment requirements for the real-time voice conversation feature and to improve production security. The most important changes are grouped below:

**Deployment and Security Documentation:**

* Added a new section to `README.md` explaining that a reverse proxy is required in production to support WebSocket connections (`/ws/conversation`) for real-time voice conversation, and to ensure HTTPS for microphone access due to browser security requirements.

**Docker Compose Configuration Updates:**

* Removed the `ports` section from the `kokoro` (TTS) and `whisper` (STT) services in the `README.md` and from the backend service in `docker-compose.yml`, indicating that these services are no longer exposed directly to the host and should be accessed internally within the Docker network. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L164-L174) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L58-L59)