### PR TITLE
feature: deploy to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ CORS_ORIGINS=["http://localhost:3000"]
 # Set to true only if serving over HTTPS
 COOKIE_SECURE=false
 
+# Rate limiting storage (use redis in production for multi-worker deployments)
+RATE_LIMIT_STORAGE=redis
+
 # Registration
 ALLOW_REGISTRATION=true
 FIRST_USER_IS_ADMIN=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-05-03
+
+### Security
+- Rate limit 5/min added to `POST /api/auth/register` to prevent account enumeration and resource abuse (A-01)
+- WebSocket authentication token now sent as first JSON message after `accept()` instead of as URL query parameter, preventing token exposure in server logs and browser history (A-02)
+- Audio uploads to STT endpoint capped at 50 MB; requests exceeding the limit return HTTP 413 (A-03)
+- `max_length=5000` enforced on TTS text and chat message fields via Pydantic (A-04)
+- `RATE_LIMIT_STORAGE=redis` set as default in `docker-compose.yml` and `.env.example` so rate limit counters are shared across workers in production (M-01)
+- `Content-Security-Policy: default-src 'self'; object-src 'none'; base-uri 'self'` header added to backend middleware and Next.js config (M-02)
+- `PATCH /api/auth/me` now returns HTTP 409 instead of 500 when the requested email is already used by another account (M-03)
+- `AdminUserCreate` schema validates email with `EmailStr` and restricts `native_language` to the `SUPPORTED_LANGUAGES` whitelist (M-04)
+- Assessment quiz sessions migrated from in-process dict (`_sessions`) to Redis with 30-minute TTL, fixing multi-worker inconsistency and memory leak (M-05)
+- Rate limit 20/min added to `POST /api/auth/refresh` (M-06)
+- `GET /api/admin/users` supports `skip`/`limit` pagination (default 20/page) with `total` count; frontend renders Previous/Next controls (M-07)
+- Rate limiter `key_func` updated to read `X-Real-IP` header set by nginx before falling back to socket address, ensuring per-client limits work correctly behind a reverse proxy (B-01)
+- `correct_answer` and `correct` fields stripped from assessment quiz responses before sending to the client (B-03)
+- `bcrypt` version constraint relaxed to `>=4.0.0` (removed `<4.0.0` upper bound) to allow security patches in future major versions (B-04)
+- CORS `allow_methods` restricted to explicit list (`GET POST PUT PATCH DELETE OPTIONS`) instead of `"*"` (I-04)
+
+### Added
+- Pagination controls (Previous / Next) on the admin users page
+- `prevPage` and `nextPage` i18n keys added to all six translation files (en, es, fr, pt, de, it)
+- `PaginatedAdminUsersResponse` schema with `items`, `total`, `skip`, `limit` fields
+
+### Fixed
+- `RATE_LIMIT_ENABLED=false` set in test conftest so rate limits do not interfere with integration tests running under the same IP
+- `test_list_users_as_admin` updated to assert on paginated response shape (`items`, `total`) instead of a flat list
+
 ## [1.2.3] - 2026-05-03
 
 ### Fixed

--- a/backend/app/core/limiter.py
+++ b/backend/app/core/limiter.py
@@ -1,10 +1,28 @@
+from fastapi import Request
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from app.core.config import settings
 
+
+def _get_real_ip(request: Request) -> str:
+    """Return the real client IP, trusting X-Real-IP set by a trusted reverse proxy.
+
+    nginx should be configured with:  proxy_set_header X-Real-IP $remote_addr;
+    This header cannot be spoofed by clients because nginx overwrites it with
+    the socket-level remote address.
+    """
+    x_real_ip = request.headers.get("X-Real-IP")
+    if x_real_ip:
+        return x_real_ip
+    # Fallback: first IP in X-Forwarded-For (may be spoofable without trusted proxy)
+    forwarded_for = request.headers.get("X-Forwarded-For", "")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
 limiter = Limiter(
-    key_func=get_remote_address,
+    key_func=_get_real_ip,
     default_limits=["200/minute"] if settings.RATE_LIMIT_ENABLED else [],
     enabled=settings.RATE_LIMIT_ENABLED,
     storage_uri="memory://" if settings.RATE_LIMIT_STORAGE == "memory" else settings.REDIS_URL,

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,29 +1,27 @@
 import secrets
 from datetime import datetime, timedelta, timezone
 
+import bcrypt
 import jwt
-from passlib.context import CryptContext
 
 from app.core.config import settings
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 # Pre-computed dummy hash used in login to prevent user-enumeration via timing.
-# Computed once at startup so bcrypt backend is initialized before any request.
-_DUMMY_HASH: str = pwd_context.hash("freelingo_dummy_placeholder")
+# Computed once at startup so bcrypt is initialized before any request.
+_DUMMY_HASH: bytes = bcrypt.hashpw(b"freelingo_dummy_placeholder", bcrypt.gensalt())
 
 
 def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
 def verify_password(plain: str, hashed: str) -> bool:
-    return pwd_context.verify(plain, hashed)
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
 
 
 def dummy_verify() -> None:
     """Run a no-op bcrypt verify to keep constant timing when user is not found."""
-    pwd_context.verify("freelingo_dummy_placeholder", _DUMMY_HASH)
+    bcrypt.checkpw(b"freelingo_dummy_placeholder", _DUMMY_HASH)
 
 
 def create_access_token(user_id: int, role: str) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,7 +50,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,6 +62,7 @@ async def security_headers_middleware(request: Request, call_next) -> Response:
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["X-XSS-Protection"] = "0"  # Modern browsers ignore it; CSP is the right tool
+    response.headers["Content-Security-Policy"] = "default-src 'self'; object-src 'none'; base-uri 'self'"
     if settings.COOKIE_SECURE:
         response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
     return response

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,8 +1,8 @@
 import secrets
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from redis.asyncio import Redis
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -15,6 +15,7 @@ from app.schemas.admin import (
     AdminUserResponse,
     AdminUserUpdate,
     InviteResponse,
+    PaginatedAdminUsersResponse,
 )
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
@@ -28,13 +29,23 @@ async def get_redis():
         await redis.aclose()
 
 
-@router.get("/users", response_model=list[AdminUserResponse])
+@router.get("/users", response_model=PaginatedAdminUsersResponse)
 async def list_users(
     admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
 ):
-    result = await db.execute(select(User).order_by(User.created_at.desc()))
-    return result.scalars().all()
+    total = await db.scalar(select(func.count(User.id)))
+    result = await db.execute(
+        select(User).order_by(User.created_at.desc()).offset(skip).limit(limit)
+    )
+    return PaginatedAdminUsersResponse(
+        items=result.scalars().all(),
+        total=total or 0,
+        skip=skip,
+        limit=limit,
+    )
 
 
 @router.post("/users", response_model=AdminUserResponse)

--- a/backend/app/routers/assessment.py
+++ b/backend/app/routers/assessment.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from redis.asyncio import Redis
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.database import get_db
 from app.core.deps import get_current_user
 from app.models.study_plan import StudyPlan
@@ -36,6 +39,16 @@ from app.services.study_plan_generator import generate_study_plan
 from app.schemas.study_plan import GenerateStudyPlanRequest
 
 router = APIRouter(prefix="/api/assessment", tags=["assessment"])
+
+_ASSESSMENT_TTL = 1800  # 30 minutes
+
+
+async def get_redis():
+    redis = Redis.from_url(settings.REDIS_URL, decode_responses=True)
+    try:
+        yield redis
+    finally:
+        await redis.aclose()
 
 
 class LegacyAnswerItem(BaseModel):
@@ -69,13 +82,14 @@ class LegacyEvalResponse(BaseModel):
     weaknesses: list[str] = []
 
 
-# Backward-compatible in-memory session store used by legacy tests.
-_sessions: dict[str, dict] = {}
+# Backward-compatible session store backed by Redis.
+_sessions = None  # kept as sentinel so conftest import doesn't break
 
 
 @router.get("/start", response_model=dict)
 async def start_assessment(
     current_user: User = Depends(get_current_user),
+    redis: Redis = Depends(get_redis),
 ):
     try:
         quiz_payload = await llm_adapter.structured_output(
@@ -96,10 +110,11 @@ async def start_assessment(
 
     quiz = quiz_payload.model_dump() if isinstance(quiz_payload, BaseModel) else quiz_payload
     session_id = str(uuid4())
-    _sessions[str(current_user.id)] = {
-        "session_id": session_id,
-        "quiz": quiz,
-    }
+    await redis.setex(
+        f"assessment:{current_user.id}",
+        _ASSESSMENT_TTL,
+        json.dumps({"session_id": session_id, "quiz": quiz}),
+    )
     return {"quiz": quiz, "session_id": session_id}
 
 
@@ -107,10 +122,12 @@ async def start_assessment(
 async def submit_assessment(
     data: LegacyAssessmentSubmitRequest,
     current_user: User = Depends(get_current_user),
+    redis: Redis = Depends(get_redis),
 ):
-    session = _sessions.get(str(current_user.id))
-    if not session:
+    session_raw = await redis.get(f"assessment:{current_user.id}")
+    if not session_raw:
         raise HTTPException(status_code=404, detail="No active assessment session.")
+    session = json.loads(session_raw)
 
     try:
         eval_payload = await llm_adapter.structured_output(
@@ -137,7 +154,7 @@ async def submit_assessment(
     except LLMError as e:
         raise HTTPException(status_code=502, detail=f"Assessment evaluation failed: {e}")
     finally:
-        _sessions.pop(str(current_user.id), None)
+        await redis.delete(f"assessment:{current_user.id}")
 
     result = eval_payload.model_dump() if isinstance(eval_payload, BaseModel) else eval_payload
     return AssessmentResult(

--- a/backend/app/routers/assessment.py
+++ b/backend/app/routers/assessment.py
@@ -42,6 +42,21 @@ router = APIRouter(prefix="/api/assessment", tags=["assessment"])
 
 _ASSESSMENT_TTL = 1800  # 30 minutes
 
+_ANSWER_FIELDS = frozenset({"correct_answer", "correct"})
+
+
+def _strip_answers(quiz: dict) -> dict:
+    """Remove correct-answer fields from quiz questions before sending to the client.
+
+    B-03: prevents exposing correct answers in the API response, which would
+    allow users to cheat by inspecting network traffic.
+    """
+    questions = [
+        {k: v for k, v in q.items() if k not in _ANSWER_FIELDS}
+        for q in quiz.get("questions", [])
+    ]
+    return {**quiz, "questions": questions}
+
 
 async def get_redis():
     redis = Redis.from_url(settings.REDIS_URL, decode_responses=True)
@@ -115,7 +130,7 @@ async def start_assessment(
         _ASSESSMENT_TTL,
         json.dumps({"session_id": session_id, "quiz": quiz}),
     )
-    return {"quiz": quiz, "session_id": session_id}
+    return {"quiz": _strip_answers(quiz), "session_id": session_id}
 
 
 @router.post("/submit", response_model=AssessmentResult)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -40,7 +40,9 @@ async def get_redis():
 
 
 @router.post("/register", response_model=dict)
+@limiter.limit("5/minute")
 async def register(
+    request: Request,
     data: RegisterRequest,
     db: AsyncSession = Depends(get_db),
     redis: Redis = Depends(get_redis),
@@ -136,6 +138,7 @@ async def login(
 
 
 @router.post("/refresh", response_model=TokenResponse)
+@limiter.limit("20/minute")
 async def refresh(
     request: Request,
     response: Response,
@@ -198,7 +201,10 @@ async def update_me(
 ):
     if data.display_name is not None:
         current_user.display_name = data.display_name
-    if data.email is not None:
+    if data.email is not None and data.email != current_user.email:
+        dup = await db.execute(select(User).where(User.email == data.email))
+        if dup.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail="Email already taken")
         current_user.email = data.email
     if data.password is not None:
         current_user.hashed_password = hash_password(data.password)

--- a/backend/app/routers/conversation.py
+++ b/backend/app/routers/conversation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 logger = logging.getLogger(__name__)
 from jwt.exceptions import PyJWTError
@@ -22,15 +22,19 @@ router = APIRouter(tags=["conversation"])
 @router.websocket("/ws/conversation")
 async def conversation_ws(
     websocket: WebSocket,
-    token: str = Query(...),
 ) -> None:
-    # --- Auth ---
+    # --- Accept first, then authenticate via first JSON message ---
+    await websocket.accept()
+
     try:
+        auth_msg = await asyncio.wait_for(websocket.receive_json(), timeout=10.0)
+        token = auth_msg.get("token", "")
         payload = decode_access_token(token)
         user_id = int(payload["sub"])
-    except (PyJWTError, KeyError, ValueError):
-        logger.warning("[conversation] Invalid token — closing WS 1008")
-        await websocket.close(code=1008)   # Policy violation
+    except (asyncio.TimeoutError, PyJWTError, KeyError, ValueError, Exception):
+        logger.warning("[conversation] Auth failed — closing WS 1008")
+        await websocket.send_json({"type": "error", "code": "auth_failed", "message": "Authentication failed"})
+        await websocket.close(code=1008)
         return
 
     async with AsyncSessionLocal() as db:
@@ -45,7 +49,6 @@ async def conversation_ws(
         stt_service = getattr(websocket.app.state, "stt_service", None)
         if tts_service is None or stt_service is None:
             logger.warning("[conversation] TTS or STT disabled — rejecting WS for user %s", user_id)
-            await websocket.accept()
             await websocket.send_json({
                 "type": "error",
                 "code": "services_disabled",
@@ -70,7 +73,7 @@ async def conversation_ws(
 
     logger.info("[conversation] Session started — user=%s cefr=%s max_duration=%ss inactivity=%ss",
                 user_id, cefr_level, max_duration, inactivity_timeout)
-    await websocket.accept()
+    # (already accepted at the top)
 
     pipeline = ConversationPipeline(
         llm=llm_adapter,

--- a/backend/app/routers/stt.py
+++ b/backend/app/routers/stt.py
@@ -20,5 +20,7 @@ async def speech_to_text(
     if stt_service is None:
         raise HTTPException(status_code=503, detail="STT service is not enabled")
     audio_bytes = await audio.read()
+    if len(audio_bytes) > 50 * 1024 * 1024:  # 50 MB
+        raise HTTPException(status_code=413, detail="Audio file too large (max 50 MB)")
     text = await stt_service.transcribe(audio_bytes, audio.filename or "audio.webm")
     return STTResponse(text=text)

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -3,16 +3,27 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, EmailStr, Field, field_serializer, field_validator
+
+SUPPORTED_LANGUAGES = {
+    "en", "es", "fr", "pt", "de", "it", "zh", "ja", "ko", "ar", "ru", "nl", "pl",
+}
 
 
 class AdminUserCreate(BaseModel):
     username: str = Field(min_length=3, max_length=50, pattern=r"^[\w.-]+$")
-    email: Optional[str] = None
+    email: Optional[EmailStr] = None
     password: str = Field(min_length=8, max_length=128)
     display_name: str = Field(max_length=100)
     native_language: str = Field(min_length=2, max_length=5)
     role: Literal["user", "admin"] = "user"
+
+    @field_validator("native_language")
+    @classmethod
+    def validate_language(cls, v: str) -> str:
+        if v not in SUPPORTED_LANGUAGES:
+            raise ValueError(f"Unsupported language code: {v}")
+        return v
 
 
 class AdminUserUpdate(BaseModel):
@@ -41,3 +52,10 @@ class AdminUserResponse(BaseModel):
 
 class InviteResponse(BaseModel):
     invite_url: str
+
+
+class PaginatedAdminUsersResponse(BaseModel):
+    items: list[AdminUserResponse]
+    total: int
+    skip: int
+    limit: int

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ChatRequest(BaseModel):
-    message: str
+    message: str = Field(min_length=1, max_length=5000)
     conversation_id: Optional[int] = None
 
 

--- a/backend/app/schemas/tts_stt.py
+++ b/backend/app/schemas/tts_stt.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class TTSRequest(BaseModel):
-    text: str
+    text: str = Field(min_length=1, max_length=5000)
     voice: Optional[str] = None
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ pydantic-settings
 pydantic[email]
 PyJWT>=2.8
 passlib[bcrypt]
-bcrypt>=3.2.2,<4.0.0
+bcrypt>=4.0.0
 redis>=5.0
 openai>=1.30
 anthropic>=0.25

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,6 @@ alembic
 pydantic-settings
 pydantic[email]
 PyJWT>=2.8
-passlib[bcrypt]
 bcrypt>=4.0.0
 redis>=5.0
 openai>=1.30

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
 os.environ["SECRET_KEY"] = "test-secret-key-for-pytest"
+os.environ["RATE_LIMIT_ENABLED"] = "false"
 
 import pytest
 import pytest_asyncio

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -31,9 +31,7 @@ async def setup_db(test_engine):
 
 @pytest_asyncio.fixture(autouse=True)
 async def clear_sessions():
-    from app.routers.assessment import _sessions
-
-    _sessions.clear()
+    # Sessions are now stored in Redis (per-test mock_redis starts empty).
     yield
 
 
@@ -71,12 +69,14 @@ async def client(db_session, mock_redis):
 
     app.dependency_overrides[get_db] = override_get_db
 
-    # Override Redis in auth and admin routers
+    # Override Redis in auth, admin and assessment routers
     from app.routers.auth import get_redis as auth_get_redis
     from app.routers.admin import get_redis as admin_get_redis
+    from app.routers.assessment import get_redis as assessment_get_redis
 
     app.dependency_overrides[auth_get_redis] = lambda: mock_redis
     app.dependency_overrides[admin_get_redis] = lambda: mock_redis
+    app.dependency_overrides[assessment_get_redis] = lambda: mock_redis
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -8,8 +8,10 @@ async def test_list_users_as_admin(client, admin_user):
     response = await client.get("/api/admin/users", headers=headers)
     assert response.status_code == 200
     data = response.json()
-    assert isinstance(data, list)
-    assert any(u["username"] == "admin" for u in data)
+    assert "items" in data
+    assert "total" in data
+    assert data["total"] >= 1
+    assert any(u["username"] == "admin" for u in data["items"])
 
 
 @pytest.mark.asyncio
@@ -162,3 +164,80 @@ async def test_create_invite_as_non_admin(client, test_user):
 
     response = await client.post("/api/admin/invite", headers=headers)
     assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_user_invalid_language(client, admin_user):
+    """M-04: AdminUserCreate should reject unsupported native_language codes."""
+    admin, headers = admin_user
+
+    response = await client.post(
+        "/api/admin/users",
+        headers=headers,
+        json={
+            "username": "langtest",
+            "password": "pass1234",
+            "display_name": "Lang Test",
+            "native_language": "xx",  # unsupported
+            "role": "user",
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_user_invalid_email(client, admin_user):
+    """M-04: AdminUserCreate should reject malformed email addresses."""
+    admin, headers = admin_user
+
+    response = await client.post(
+        "/api/admin/users",
+        headers=headers,
+        json={
+            "username": "emailtest",
+            "password": "pass1234",
+            "display_name": "Email Test",
+            "native_language": "es",
+            "email": "not-an-email",
+            "role": "user",
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_users_pagination(client, admin_user, db_session):
+    """M-07: GET /api/admin/users should support skip/limit pagination."""
+    from app.models.user import User
+    from app.core.security import hash_password
+
+    admin, headers = admin_user
+
+    for i in range(5):
+        db_session.add(User(
+            username=f"paguser{i}",
+            email=f"paguser{i}@test.com",
+            display_name=f"Pag {i}",
+            hashed_password=hash_password("pass1234"),
+            role="user",
+            native_language="es",
+            is_active=True,
+        ))
+    await db_session.commit()
+
+    resp_page1 = await client.get("/api/admin/users?skip=0&limit=3", headers=headers)
+    assert resp_page1.status_code == 200
+    data1 = resp_page1.json()
+    assert len(data1["items"]) == 3
+    assert data1["total"] >= 6  # 1 admin + 5 extra
+    assert data1["limit"] == 3
+
+    resp_page2 = await client.get("/api/admin/users?skip=3&limit=3", headers=headers)
+    assert resp_page2.status_code == 200
+    data2 = resp_page2.json()
+    assert len(data2["items"]) >= 1
+
+    # Usernames across pages must be disjoint
+    names1 = {u["username"] for u in data1["items"]}
+    names2 = {u["username"] for u in data2["items"]}
+    assert names1.isdisjoint(names2)

--- a/backend/tests/test_assessment.py
+++ b/backend/tests/test_assessment.py
@@ -130,3 +130,35 @@ async def test_start_assessment_handles_llm_unavailable(client, test_user):
     ):
         response = await client.get("/api/assessment/start", headers=headers)
         assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_start_assessment_strips_correct_answers(client, test_user):
+    """B-03: correct_answer and correct fields must not be returned to the client."""
+    user, headers = test_user
+
+    mock_quiz = {
+        "questions": [
+            {
+                "id": 1,
+                "type": "multiple_choice",
+                "difficulty": "A1",
+                "question": "What is the capital of France?",
+                "options": ["A. London", "B. Paris", "C. Berlin", "D. Madrid"],
+                "correct_answer": "B",
+                "correct": "B",
+            },
+        ]
+    }
+
+    with patch(
+        "app.routers.assessment.llm_adapter.structured_output",
+        return_value=mock_quiz,
+    ):
+        response = await client.get("/api/assessment/start", headers=headers)
+        assert response.status_code == 200
+        questions = response.json()["quiz"]["questions"]
+        assert len(questions) == 1
+        assert "correct_answer" not in questions[0], "correct_answer must not be exposed"
+        assert "correct" not in questions[0], "correct must not be exposed"
+        assert "question" in questions[0]  # non-sensitive fields still present

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -276,3 +276,56 @@ async def test_patch_me(client, test_user):
     assert response.status_code == 200
     data = response.json()
     assert data["display_name"] == "Updated Name"
+
+
+@pytest.mark.asyncio
+async def test_patch_me_duplicate_email(client, db_session):
+    """M-03: PATCH /me should reject an email already used by another user."""
+    from app.models.user import User
+    from app.core.security import hash_password, create_access_token
+
+    user_a = User(
+        username="user_a",
+        email="user_a@test.com",
+        display_name="A",
+        hashed_password=hash_password("pass1234"),
+        role="user",
+        native_language="es",
+        is_active=True,
+    )
+    user_b = User(
+        username="user_b",
+        email="user_b@test.com",
+        display_name="B",
+        hashed_password=hash_password("pass1234"),
+        role="user",
+        native_language="en",
+        is_active=True,
+    )
+    db_session.add(user_a)
+    db_session.add(user_b)
+    await db_session.commit()
+    await db_session.refresh(user_b)
+
+    token = create_access_token(user_b.id, user_b.role)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = await client.patch(
+        "/api/auth/me",
+        headers=headers,
+        json={"email": "user_a@test.com"},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_patch_me_same_email_allowed(client, test_user):
+    """M-03: PATCH /me with the user's own current email should succeed."""
+    user, headers = test_user
+
+    response = await client.patch(
+        "/api/auth/me",
+        headers=headers,
+        json={"email": "test@example.com"},
+    )
+    assert response.status_code == 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       STT_BASE_URL: ${STT_BASE_URL:-http://whisper:9000}
       CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}
       COOKIE_SECURE: ${COOKIE_SECURE:-false}
+      RATE_LIMIT_STORAGE: ${RATE_LIMIT_STORAGE:-redis}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
     depends_on:
       postgres:

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -34,6 +34,7 @@ const nextConfig: NextConfig = {
           // with client-side navigation in Next.js (headers must be global).
           { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
           { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
+          { key: 'Content-Security-Policy', value: "default-src 'self'; object-src 'none'; base-uri 'self'" },
         ],
       },
     ]

--- a/frontend/src/app/(app)/admin/users/page.tsx
+++ b/frontend/src/app/(app)/admin/users/page.tsx
@@ -27,6 +27,9 @@ const LANGUAGES = [
 export default function AdminUsersPage() {
   const t = useTranslations('admin')
   const [users, setUsers] = useState<AdminUserItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(0)
+  const PAGE_SIZE = 20
   const [loading, setLoading] = useState(true)
   const [showCreate, setShowCreate] = useState(false)
   const [inviteUrl, setInviteUrl] = useState('')
@@ -42,12 +45,14 @@ export default function AdminUsersPage() {
   const [deletePending, setDeletePending] = useState<AdminUserItem | null>(null)
   const currentUserId = useAuthStore((s) => s.user?.id)
 
-  const loadUsers = useCallback(async () => {
+  const loadUsers = useCallback(async (pageIndex = 0) => {
     setLoading(true)
     try {
-      const res = await apiFetch('/api/admin/users')
+      const res = await apiFetch(`/api/admin/users?skip=${pageIndex * PAGE_SIZE}&limit=${PAGE_SIZE}`)
       if (res.ok) {
-        setUsers(await res.json())
+        const data = await res.json()
+        setUsers(data.items)
+        setTotal(data.total)
       } else if (res.status === 403) {
         setError('Admin access required')
       }
@@ -58,7 +63,7 @@ export default function AdminUsersPage() {
     }
   }, [])
 
-  useEffect(() => { loadUsers() }, [loadUsers])
+  useEffect(() => { loadUsers(page) }, [loadUsers, page])
 
   async function createUser(e: React.FormEvent) {
     e.preventDefault()
@@ -72,7 +77,7 @@ export default function AdminUsersPage() {
       if (!res.ok) throw new Error((await res.json()).detail)
       setShowCreate(false)
       setForm({ username: '', email: '', password: '', display_name: '', native_language: 'es', role: 'user' })
-      await loadUsers()
+      await loadUsers(page)
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to create user')
     }
@@ -84,7 +89,7 @@ export default function AdminUsersPage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ is_active: !user.is_active }),
     })
-    await loadUsers()
+    await loadUsers(page)
   }
 
   async function deleteUser(user: AdminUserItem) {
@@ -94,7 +99,15 @@ export default function AdminUsersPage() {
       const data = await res.json().catch(() => ({}))
       setError(data.detail || 'Failed to delete user')
     } else {
-      await loadUsers()
+      // Si era el último de la página, retroceder una
+      const newTotal = total - 1
+      const maxPage = Math.max(0, Math.ceil(newTotal / PAGE_SIZE) - 1)
+      const targetPage = Math.min(page, maxPage)
+      if (targetPage !== page) {
+        setPage(targetPage)
+      } else {
+        await loadUsers(targetPage)
+      }
     }
   }
 
@@ -206,7 +219,7 @@ export default function AdminUsersPage() {
         <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
           <span className="text-fl-label text-fl-muted-2">●</span>
           <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">{t('users')}</span>
-          <span className="ml-auto font-mono text-fl-hint text-fl-muted-4 uppercase tracking-widest">{users.length} {t('total')}</span>
+          <span className="ml-auto font-mono text-fl-hint text-fl-muted-4 uppercase tracking-widest">{total} {t('total')}</span>
         </div>
         {users.length === 0 ? (
           <p className="px-6 py-8 font-mono text-xs text-fl-muted-2 text-center">{t('noUsers')}</p>
@@ -254,6 +267,29 @@ export default function AdminUsersPage() {
           </div>
         )}
       </div>
+
+      {/* Pagination controls */}
+      {total > PAGE_SIZE && (
+        <div className="flex items-center justify-between border border-fl-border bg-fl-surface px-6 py-3">
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="border border-fl-border px-4 py-2 font-mono text-fl-label tracking-widest uppercase text-fl-muted-1 hover:text-fl-fg hover:border-fl-border-2 transition-colors disabled:opacity-20 disabled:cursor-not-allowed"
+          >
+            {t('prevPage')}
+          </button>
+          <span className="font-mono text-fl-label text-fl-muted-2 tracking-widest">
+            {page + 1} / {Math.ceil(total / PAGE_SIZE)}
+          </span>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={(page + 1) * PAGE_SIZE >= total}
+            className="border border-fl-border px-4 py-2 font-mono text-fl-label tracking-widest uppercase text-fl-muted-1 hover:text-fl-fg hover:border-fl-border-2 transition-colors disabled:opacity-20 disabled:cursor-not-allowed"
+          >
+            {t('nextPage')}
+          </button>
+        </div>
+      )}
 
       <ConfirmDialog
         open={deletePending !== null}

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -206,7 +206,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             {user?.displayName || user?.username}
           </p>
           <p className="text-fl-label font-mono text-fl-muted-4 mb-3">@{user?.username}</p>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.3</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.4</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -312,7 +312,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             )}
             <div className="border-t border-fl-border mx-5 mt-2 pt-3">
               <p className="font-mono text-fl-label text-fl-muted-4 mb-1">@{user?.username}</p>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.3</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.4</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/components/conversation/ConversationMode.tsx
+++ b/frontend/src/components/conversation/ConversationMode.tsx
@@ -94,12 +94,15 @@ export default function ConversationMode() {
   // ─── WebSocket ────────────────────────────────────────────────────────────
   const connectWs = useCallback(
     (token: string) => {
-      const url = buildConversationWsUrl(token)
+      const url = buildConversationWsUrl()
       const ws = new WebSocket(url)
       ws.binaryType = 'arraybuffer'
       wsRef.current = ws
 
-      ws.onopen = () => setStatus('live')
+      ws.onopen = () => {
+        ws.send(JSON.stringify({ type: 'auth', token }))
+        setStatus('live')
+      }
 
       ws.onmessage = async (event) => {
         // Binary → TTS audio chunk

--- a/frontend/src/lib/conversation-ws.ts
+++ b/frontend/src/lib/conversation-ws.ts
@@ -11,7 +11,7 @@
  *  - If NEXT_PUBLIC_API_URL is empty (same-origin / Traefik fronting both),
  *    derive the WS base from window.location.
  */
-export function buildConversationWsUrl(token: string): string {
+export function buildConversationWsUrl(): string {
   const base = (process.env.NEXT_PUBLIC_API_URL ?? '').trim()
 
   let wsBase: string
@@ -24,7 +24,7 @@ export function buildConversationWsUrl(token: string): string {
     wsBase = `${proto}//${window.location.host}`
   }
 
-  return `${wsBase}/ws/conversation?token=${encodeURIComponent(token)}`
+  return `${wsBase}/ws/conversation`
 }
 
 // ─── Incoming WS message types ───────────────────────────────────────────────

--- a/messages/de.json
+++ b/messages/de.json
@@ -393,7 +393,9 @@
     "total": "gesamt",
     "delete": "Löschen",
     "inviteBtn": "+ Einladungslink",
-    "createUserBtn": "+ Benutzer erstellen"
+    "createUserBtn": "+ Benutzer erstellen",
+    "prevPage": "← Zurück",
+    "nextPage": "Weiter →"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/en.json
+++ b/messages/en.json
@@ -393,7 +393,9 @@
     "total": "total",
     "delete": "Delete",
     "inviteBtn": "+ Invite Link",
-    "createUserBtn": "+ Create User"
+    "createUserBtn": "+ Create User",
+    "prevPage": "← Prev",
+    "nextPage": "Next →"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/es.json
+++ b/messages/es.json
@@ -393,7 +393,9 @@
     "total": "total",
     "delete": "Eliminar",
     "inviteBtn": "+ Enlace de invitación",
-    "createUserBtn": "+ Crear usuario"
+    "createUserBtn": "+ Crear usuario",
+    "prevPage": "← Anterior",
+    "nextPage": "Siguiente →"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -393,7 +393,9 @@
     "total": "total",
     "delete": "Supprimer",
     "inviteBtn": "+ Lien d'invitation",
-    "createUserBtn": "+ Créer un utilisateur"
+    "createUserBtn": "+ Créer un utilisateur",
+    "prevPage": "← Préc.",
+    "nextPage": "Suiv. →"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/it.json
+++ b/messages/it.json
@@ -393,7 +393,9 @@
     "total": "totale",
     "delete": "Elimina",
     "inviteBtn": "+ Link di invito",
-    "createUserBtn": "+ Crea utente"
+    "createUserBtn": "+ Crea utente",
+    "prevPage": "← Prec.",
+    "nextPage": "Succ. →"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -393,7 +393,9 @@
     "total": "total",
     "delete": "Eliminar",
     "inviteBtn": "+ Link de convite",
-    "createUserBtn": "+ Criar utilizador"
+    "createUserBtn": "+ Criar utilizador",
+    "prevPage": "← Anterior",
+    "nextPage": "Seguinte →"
   },
   "faq": {
     "title": "FAQ",

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.2.3**
+**1.2.4**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request introduces several important security, stability, and usability improvements across the backend and admin features. The main focus is on strengthening rate limiting, authentication, and data validation, as well as improving multi-worker compatibility and API consistency. Below is a summary of the most significant changes:

---

**Security and Rate Limiting Enhancements**
* Added rate limits: 5/minute for `POST /api/auth/register` and 20/minute for `POST /api/auth/refresh` to prevent abuse and resource exhaustion. [[1]](diffhunk://#diff-b05ab53047dc54d983428eb226c0072641769fe81e60bf6e22f581239c95ce81R43-R45) [[2]](diffhunk://#diff-b05ab53047dc54d983428eb226c0072641769fe81e60bf6e22f581239c95ce81R141)
* Rate limiter now uses the `X-Real-IP` header (set by nginx) for per-client limits, ensuring correct behavior behind a reverse proxy and preventing spoofing.
* Default rate limit storage is now Redis (in `.env.example` and `docker-compose.yml`), ensuring counters are shared across workers in production.
* CORS `allow_methods` is now restricted to an explicit list instead of `"*"`, reducing attack surface.
* HTTP security headers improved: a strict Content Security Policy is now set on all responses.

**Authentication and Authorization Improvements**
* WebSocket authentication token is now sent in the first JSON message after connection acceptance, rather than as a URL query parameter—preventing token leaks in logs and browser history. [[1]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307L25-R37) [[2]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307L6-R6) [[3]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307L73-R76)
* `PATCH /api/auth/me` now returns HTTP 409 if the requested email is already in use, instead of a server error.

**Data Validation and Security**
* `AdminUserCreate` schema now validates `email` with `EmailStr` and restricts `native_language` to a whitelist of supported languages.
* `bcrypt` is now used directly for password hashing and verification, and the version constraint is relaxed to allow future security updates.
* Maximum length of 5000 characters enforced on TTS and chat message fields via Pydantic validation. [[1]](diffhunk://#diff-e98d7a32427b4fb297662004f695b6b959db83dc7352a73ae2a78e8f53f8c736L3-R7) [[2]](diffhunk://#diff-56794a267372a62809c313618d5762e653e74d12c6beca4814429cf4c4acd2e9L4-R8)
* Audio uploads to the STT endpoint are now capped at 50 MB; larger files are rejected with HTTP 413.

**Admin and Assessment Features**
* Admin users API (`GET /api/admin/users`) now returns paginated results with `items`, `total`, `skip`, and `limit` fields, and the frontend supports Previous/Next controls. [[1]](diffhunk://#diff-779d28ecc2f5d7e31f90033747661b50475f4f71c9c34c6ec83bc3a642b6e26eL31-R48) [[2]](diffhunk://#diff-6f89f26da8b85c0abe62edebbb358374b67523619b8d51bd87f191c56cbf58d1R55-R61) [[3]](diffhunk://#diff-779d28ecc2f5d7e31f90033747661b50475f4f71c9c34c6ec83bc3a642b6e26eR18)
* Assessment quiz sessions are now stored in Redis with a 30-minute TTL, resolving memory leaks and multi-worker inconsistencies. [[1]](diffhunk://#diff-9d9ea73de6ab3e1c81912198f347fe6fb535fc223b39a1bdf2078648c142008dR43-R67) [[2]](diffhunk://#diff-9d9ea73de6ab3e1c81912198f347fe6fb535fc223b39a1bdf2078648c142008dL72-R107) [[3]](diffhunk://#diff-9d9ea73de6ab3e1c81912198f347fe6fb535fc223b39a1bdf2078648c142008dL99-R145) [[4]](diffhunk://#diff-9d9ea73de6ab3e1c81912198f347fe6fb535fc223b39a1bdf2078648c142008dL140-R172)
* Assessment quiz responses no longer expose `correct_answer` and `correct` fields to the client, preventing cheating.

**Other Notable Improvements**
* Changelog updated to document all notable changes in this release.

---

These changes collectively improve the robustness, security, and maintainability of the backend and admin interfaces.