### PR TITLE
feature: deploy to main

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,7 +62,7 @@ async def security_headers_middleware(request: Request, call_next) -> Response:
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["X-XSS-Protection"] = "0"  # Modern browsers ignore it; CSP is the right tool
-    response.headers["Content-Security-Policy"] = "default-src 'self'; object-src 'none'; base-uri 'self'"
+    response.headers["Content-Security-Policy"] = "default-src 'self'; object-src 'none'; base-uri 'self'"  # API-only responses (JSON/binary)
     if settings.COOKIE_SECURE:
         response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
     return response

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -34,7 +34,21 @@ const nextConfig: NextConfig = {
           // with client-side navigation in Next.js (headers must be global).
           { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
           { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
-          { key: 'Content-Security-Policy', value: "default-src 'self'; object-src 'none'; base-uri 'self'" },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline'",
+              "connect-src 'self' ws: wss:",
+              "img-src 'self' data: blob:",
+              "media-src 'self' blob:",
+              "worker-src 'self' blob:",
+              "font-src 'self'",
+              "object-src 'none'",
+              "base-uri 'self'",
+            ].join('; '),
+          },
         ],
       },
     ]

--- a/specs/architecture.instructions.md
+++ b/specs/architecture.instructions.md
@@ -276,9 +276,9 @@ Per-unit competency tracking (Phase 1+).
 
 | Method | Path | Rate limit | Description |
 |--------|------|------------|-------------|
-| POST | `/register` | Invite-gated | Creates account (respects `ALLOW_REGISTRATION` and invite token) |
+| POST | `/register` | 5/min (+ invite-gated) | Creates account (respects `ALLOW_REGISTRATION` and invite token) |
 | POST | `/login` | 10/min | Returns access_token (JWT, 15 min) + refresh_token in httpOnly cookie (30 days) |
-| POST | `/refresh` | 10/min | Rotates refresh token, returns new access_token |
+| POST | `/refresh` | 20/min | Rotates refresh token, returns new access_token |
 | POST | `/logout` | None | Deletes refresh token from Redis, clears cookie |
 | GET | `/me` | None | Returns authenticated user profile |
 | PATCH | `/me` | None | Updates display_name, email, password, english_variant, conversation settings |
@@ -287,7 +287,7 @@ Per-unit competency tracking (Phase 1+).
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/users` | Lists all users |
+| GET | `/users` | Lists users (paginated). Query params: `skip` (default 0) and `limit` (default 20, max 100). Returns `{items, total, skip, limit}`. |
 | POST | `/users` | Creates user directly (bypasses `ALLOW_REGISTRATION`) |
 | GET | `/users/{id}` | User detail |
 | PATCH | `/users/{id}` | Edit role, is_active, display_name |
@@ -370,6 +370,8 @@ Per-unit competency tracking (Phase 1+).
 ### WebSocket — `/ws/conversation` (Phase 3)
 
 Full-duplex voice conversation pipeline. Requires `TTS_ENABLED=true` and `STT_ENABLED=true` — rejects connections otherwise.
+
+**Authentication**: After the WebSocket handshake is accepted, the client must send a JSON message `{"type": "auth", "token": "<access_token>"}` within 10 seconds. If the message is missing, malformed, or the token is invalid, the server closes the connection with code 1008.
 
 **Message flow**: Client sends audio chunks → STT transcription → LLM generates response (streamed) → sentence-level TTS → MP3 audio chunks returned.
 

--- a/specs/phase-3-conversation.instructions.md
+++ b/specs/phase-3-conversation.instructions.md
@@ -96,8 +96,8 @@ At T-60 seconds, a `SessionTimeoutBanner` appears with a countdown. When the tim
 ### Connection (`/ws/conversation`)
 
 - **Protocol**: WebSocket
-- **Auth**: JWT access token passed as query parameter (`?token=<jwt>`)
-- **Guard**: rejects connection with 4001 close code if `TTS_ENABLED=false` or `STT_ENABLED=false`
+- **Auth**: After the WebSocket handshake is accepted, the client sends a JSON message `{"type": "auth", "token": "<access_token>"}` within 10 seconds. Sending the token in the URL is intentionally avoided to prevent it from appearing in server access logs.
+- **Guard**: rejects connection with code 1008 if the auth message is missing/invalid, or with code 1011 if `TTS_ENABLED=false` or `STT_ENABLED=false`
 - **Database**: uses an async session context manager for the user lookup (reads `conversation_max_duration` and `conversation_inactivity_timeout` from User model)
 
 ### Message types

--- a/specs/rate-limiting.instructions.md
+++ b/specs/rate-limiting.instructions.md
@@ -7,16 +7,16 @@ applyTo: "backend/app/main.py, backend/app/core/config.py, backend/app/core/limi
 
 ## Approach
 
-Uses [**slowapi**](https://github.com/laurentS/slowapi) (built on `limits`, Rust backend). Default storage is in-memory — adequate for self-hosted single-node deployments. No Redis dependency is required for rate limiting.
+Uses [**slowapi**](https://github.com/laurentS/slowapi) (built on `limits`, Rust backend). Default storage is **Redis** — consistent across restarts and multi-node deployments. Redis is already a required dependency (refresh tokens), so there is no additional infrastructure cost.
 
-For multi-node setups, switch to Redis backend via `RATE_LIMIT_STORAGE=redis` in `.env`.
+For development or trusted environments without Redis, switch to in-memory via `RATE_LIMIT_STORAGE=memory` in `.env`.
 
 ### Configuration
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting entirely |
-| `RATE_LIMIT_STORAGE` | `"memory"` | Storage backend: `"memory"` or `"redis"` |
+| `RATE_LIMIT_STORAGE` | `"redis"` | Storage backend: `"redis"` (default) or `"memory"` |
 
 The global default limit is 200 requests/minute for all unclassified endpoints.
 
@@ -34,8 +34,8 @@ The global default limit is 200 requests/minute for all unclassified endpoints.
 | Endpoint group | Limit | Key type | Rationale |
 |---------------|-------|----------|-----------|
 | Auth login | 10 requests / minute | IP | Prevent brute-force on credentials |
-| Auth register | Invite-gated (no separate limit) | IP | Controlled by invite token expiry |
-| Auth refresh | 10 requests / minute | IP | Token rotation, lightweight but guard abuse |
+| Auth register | 5 requests / minute | IP | Prevent account-creation abuse; invite token provides additional gating |
+| Auth refresh | 20 requests / minute | IP | Token rotation — higher limit to avoid disrupting normal SPA refresh cycles |
 | LLM-heavy (`/api/assessment/start`, `/api/assessment/submit`, `/api/study-plan/generate`, `/api/flashcards/generate`) | 10 requests / minute | User | These call Ollama; prevent queue saturation |
 | LLM-light (`/api/lessons/*`, `/api/exercises/*`, `/api/chat`) | 30 requests / minute | User | Interactive, should feel responsive |
 | Flashcards review (`/api/flashcards/*/review`) | 60 requests / minute | User | Rapid swipes during review sessions |
@@ -49,10 +49,10 @@ The global default limit is 200 requests/minute for all unclassified endpoints.
 
 ## Rate limit key selection
 
-- **IP-based** (`get_remote_address`): used for public endpoints where no user is authenticated. Applied to: login, register, refresh, logout.
+- **IP-based** (`_get_real_ip`): used for public endpoints where no user is authenticated. Applied to: login, register, refresh, logout. The key function reads `X-Real-IP` first (set by a trusted reverse proxy), then `X-Forwarded-For`, then the socket address as a fallback. This ensures correct IP identification behind Traefik/nginx.
 - **User-based** (`get_user_key` → `str(current_user.id)`): used for all authenticated endpoints. More granular than IP and survives IP changes.
 
-The rate limiter is configured globally with `key_func=get_remote_address` as the default; user-based endpoints override this with `key_func=get_user_key` on each decorator.
+The rate limiter is configured globally with `key_func=_get_real_ip` as the default; user-based endpoints override this with `key_func=get_user_key` on each decorator.
 
 ---
 
@@ -94,7 +94,7 @@ The WebSocket conversation endpoint (`/ws/conversation`) is **not** rate-limited
 Since FreeLingo is self-hosted (typically single admin + few users):
 
 - **Defaults are generous** — limits prevent abuse, not normal usage. A single user doing flashcards review generates approximately 1-2 requests/second, well within limits.
-- **In-memory storage** — no extra infrastructure needed. Process restart loses counters (acceptable for self-hosted — the application restarts infrequently).
-- **Redis backend optional** — set `RATE_LIMIT_STORAGE=redis` if running multiple backend instances behind a load balancer.
+- **Redis storage** — counters persist across restarts and are shared across backend instances. Redis is already required for auth (refresh tokens), so no extra infrastructure is needed.
+- **In-memory backend optional** — set `RATE_LIMIT_STORAGE=memory` for local development without Redis.
 - **Disable fully** — set `RATE_LIMIT_ENABLED=false` if rate limiting causes issues in a trusted environment.
 - Limits are environment-configurable, not hardcoded — adjust in `.env` if the defaults don't match the deployment scale.


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) configuration for both the backend API and the frontend application. The backend CSP remains unchanged but is clarified with a comment, while the frontend CSP is significantly expanded to better support modern web features such as inline scripts/styles, web sockets, and various resource types.

**Frontend Content Security Policy enhancements:**

* Expanded the `Content-Security-Policy` header in `next.config.ts` to allow inline scripts and styles, web socket connections, images from `data:` and `blob:` sources, media and worker blobs, and other resource-specific directives for improved compatibility and security.

**Backend Content Security Policy clarification:**

* Added a clarifying comment to the backend's CSP header indicating it applies to API-only (JSON/binary) responses; the policy itself remains unchanged.