### PR TITLE
feature: deploy to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Conversation mode: LLM now always responds in English regardless of the language the student uses; if the student speaks in another language the tutor replies in English and gently encourages them to try in English
 - License changed from Apache 2.0 to GNU Affero General Public License v3 (AGPL v3)
+- `DurationOption` interface cleaned up: `label`, `sublabel`, and `approxLessons` string fields removed; `intensity` typed as `'intensive' | 'standard' | 'relaxed' | 'very_relaxed'`; `GOAL_OPTIONS` entries no longer carry a `label` field — all display strings are now derived from translations at render time
+
+### Added
+- Full i18n coverage for all previously hardcoded UI strings across 6 locale files (en, es, fr, pt, de, it):
+  - `common.close`
+  - `grammar.explanation`, `grammar.backLink`
+  - `plan.unitLabel`, `plan.grammarCovered`, `plan.noLessons`, `plan.weekDay`, `plan.lessonTypes.*` (grammar / vocabulary / reading / writing / conversation / review / level_test), `plan.levelComplete`, `plan.levelCompleteDesc`, `plan.levelCompleteHint`, `plan.beginLevelTest`, `plan.nLessons`, `plan.nGrammar`, `plan.levelTestLabel`, `plan.unitAriaLabel`
+  - `assessment.step1/2/3`, `assessment.studiedBefore`, `assessment.studiedBeforeHint`, `assessment.beginnerOption/Hint`, `assessment.hasExperienceOption/Hint`, `assessment.skills.*`, `assessment.howManyWeeks`, `assessment.nWeeks`, `assessment.intensity.*` (intensive / standard / relaxed / veryRelaxed), `assessment.approxLessons`, `assessment.daysPerWeek`, `assessment.mainGoals`, `assessment.goals.*`, `assessment.summaryLevel/Duration/Goals`, `assessment.noneSelected`, `assessment.buildingPlan`, `assessment.startMyPlan`
+  - `common.tagline`, `voiceRecorder.*` (6 keys), `audioPlayer.*` (4 keys), `languages.*` (5 language names per locale)
+- `grammar/[slug]/page.tsx`, `UnitDrawer.tsx`, `LevelTestBanner.tsx`, `UnitCard.tsx`, `BeginnerGate.tsx`, `AdaptiveQuizCard.tsx`, `DurationSelector.tsx` now use `useTranslations` — no hardcoded English strings remain in these components
+- `VoiceRecorder.tsx` and `AudioPlayer.tsx` use `useTranslations('voiceRecorder')` / `useTranslations('audioPlayer')`
+- Login and register pages render the app tagline via `tCommon('tagline')`
+- ADMIN nav badge rendered via `tNav('admin')`
+- Phrasebook register badge rendered via `t(phrase.register)` using existing `phrasebook.formal/neutral/informal` keys
+- `LANGUAGES` constant simplified to `['es','fr','pt','de','it'] as const`; display names resolved at render time via `useTranslations('languages')` in register, settings, and admin pages
 
 ### Fixed
 - Email, password, and confirm-password inputs across login, register, settings, and admin pages now set `autoCorrect="off"`, `autoCapitalize="none"`, and `spellCheck={false}` to prevent mobile keyboards from corrupting typed values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.6] - 2026-05-03
+
+### Changed
+- Conversation mode: LLM now always responds in English regardless of the language the student uses; if the student speaks in another language the tutor replies in English and gently encourages them to try in English
+- License changed from Apache 2.0 to GNU Affero General Public License v3 (AGPL v3)
+
+### Fixed
+- Email, password, and confirm-password inputs across login, register, settings, and admin pages now set `autoCorrect="off"`, `autoCapitalize="none"`, and `spellCheck={false}` to prevent mobile keyboards from corrupting typed values
+
 ## [1.2.5] - 2026-05-03
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,4 +70,4 @@ docker compose exec backend alembic upgrade head
 
 ## License
 
-By contributing you agree that your contributions will be licensed under the [Apache 2.0 License](LICENSE).
+By contributing you agree that your contributions will be licensed under the [GNU Affero General Public License v3](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,661 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-   1. Definitions.
+                            Preamble
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+                       TERMS AND CONDITIONS
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+  0. Definitions.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+  1. Source Code.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-   END OF TERMS AND CONDITIONS
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-   APPENDIX: How to apply the Apache License to your work.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+  2. Basic Permissions.
 
-   Copyright [yyyy] [name of copyright owner]
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FreeLingo
 
-![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)
+![License](https://img.shields.io/badge/license-AGPL%20v3-blue?style=flat-square)
 ![Next.js](https://img.shields.io/badge/next.js-16-black?style=flat-square)
 ![Python](https://img.shields.io/badge/python-3.12-blue?style=flat-square)
 ![Self-hosted](https://img.shields.io/badge/self--hosted-yes-orange?style=flat-square)
@@ -238,7 +238,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting bugs, suggest
 
 ## License
 
-Distributed under the [Apache 2.0 License](LICENSE).
+Distributed under the [GNU Affero General Public License v3](LICENSE).
 
 ## Author
 

--- a/backend/app/services/conversation_pipeline.py
+++ b/backend/app/services/conversation_pipeline.py
@@ -28,6 +28,7 @@ Rules:
 - Use vocabulary appropriate for their level
 - Ask follow-up questions to keep the conversation going
 - Never break character or mention you are an AI unless directly asked
+- ALWAYS respond in English, regardless of the language the student uses. If they speak in another language, reply in English and gently encourage them to try in English.
 - NEVER use emojis, emoticons, or any Unicode pictographic symbols in your responses. They are strictly forbidden because responses are read aloud by a text-to-speech engine and emoticons produce unnatural noise (e.g. "face with tears of joy"). Plain text only.
 """
 

--- a/frontend/src/app/(app)/admin/users/page.tsx
+++ b/frontend/src/app/(app)/admin/users/page.tsx
@@ -186,6 +186,9 @@ export default function AdminUsersPage() {
                 required={required}
                 value={form[key as keyof typeof form]}
                 onChange={(e) => setForm({ ...form, [key]: e.target.value })}
+                autoCorrect={type === 'email' || type === 'password' ? 'off' : undefined}
+                autoCapitalize={type === 'email' || type === 'password' ? 'none' : undefined}
+                spellCheck={type === 'email' || type === 'password' ? false : undefined}
                 className={inputCls}
               />
             ))}

--- a/frontend/src/app/(app)/admin/users/page.tsx
+++ b/frontend/src/app/(app)/admin/users/page.tsx
@@ -16,16 +16,11 @@ interface AdminUserItem {
   is_active: boolean
 }
 
-const LANGUAGES = [
-  { code: 'es', name: 'Spanish' },
-  { code: 'fr', name: 'French' },
-  { code: 'pt', name: 'Portuguese' },
-  { code: 'de', name: 'German' },
-  { code: 'it', name: 'Italian' },
-]
+const LANGUAGES = ['es', 'fr', 'pt', 'de', 'it'] as const
 
 export default function AdminUsersPage() {
   const t = useTranslations('admin')
+  const tLang = useTranslations('languages')
   const [users, setUsers] = useState<AdminUserItem[]>([])
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(0)
@@ -197,7 +192,7 @@ export default function AdminUsersPage() {
               onChange={(e) => setForm({ ...form, native_language: e.target.value })}
               className={inputCls + ' appearance-none'}
             >
-              {LANGUAGES.map((l) => <option key={l.code} value={l.code}>{l.name}</option>)}
+              {LANGUAGES.map((code) => <option key={code} value={code}>{tLang(code)}</option>)}
             </select>
             <select
               value={form.role}

--- a/frontend/src/app/(app)/grammar/[slug]/page.tsx
+++ b/frontend/src/app/(app)/grammar/[slug]/page.tsx
@@ -3,6 +3,7 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { use } from 'react'
+import { useTranslations } from 'next-intl'
 import { grammarTopics } from '@/data/grammar'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -65,6 +66,8 @@ export default function GrammarDetailPage({
 }: {
   params: Promise<{ slug: string }>
 }) {
+  const t = useTranslations('grammar')
+  const tNav = useTranslations('nav')
   const { slug } = use(params)
   const topic = grammarTopics.find((t) => t.slug === slug)
   if (!topic) notFound()
@@ -82,7 +85,7 @@ export default function GrammarDetailPage({
       {/* Breadcrumb */}
       <nav className="flex items-center gap-2 font-mono text-fl-label text-fl-muted-3">
         <Link href="/grammar" className="hover:text-fl-fg transition-colors uppercase tracking-widest">
-          Grammar
+          {tNav('grammar')}
         </Link>
         <span>›</span>
         <span className="text-fl-muted-2 tracking-widest uppercase">{topic.level}</span>
@@ -95,7 +98,7 @@ export default function GrammarDetailPage({
         <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
           <span className="text-fl-label text-fl-muted-3">●</span>
           <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-            Grammar Reference
+            {t('backToGrammar')}
           </span>
         </div>
         <div className="px-6 py-5 space-y-3">
@@ -116,7 +119,7 @@ export default function GrammarDetailPage({
           {topic.structure && (
             <div className="border border-fl-border bg-fl-bg px-4 py-3">
               <p className="font-mono text-fl-label tracking-widest text-fl-muted-3 uppercase mb-1">
-                Structure
+                {t('structure')}
               </p>
               <p className="font-mono text-xs text-fl-fg">{topic.structure}</p>
             </div>
@@ -128,7 +131,7 @@ export default function GrammarDetailPage({
       <div className="border border-fl-border bg-fl-surface">
         <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
           <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-            Explanation
+            {t('explanation')}
           </span>
         </div>
         <div className="px-6 py-5 space-y-2">
@@ -157,7 +160,7 @@ export default function GrammarDetailPage({
         <div className="border border-fl-border bg-fl-surface">
           <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
             <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-              Key Rules
+              {t('keyRules')}
             </span>
           </div>
           <ul className="px-6 py-5 space-y-2">
@@ -176,7 +179,7 @@ export default function GrammarDetailPage({
         <div className="border border-fl-border bg-fl-surface">
           <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
             <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-              Examples
+              {t('examples')}
             </span>
           </div>
           <div className="px-6 py-5 space-y-3">
@@ -197,7 +200,7 @@ export default function GrammarDetailPage({
         <div className="border border-fl-border bg-fl-surface">
           <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
             <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-              Common Mistakes
+              {t('commonMistakes')}
             </span>
           </div>
           <div className="px-6 py-5 space-y-4">
@@ -229,7 +232,7 @@ export default function GrammarDetailPage({
         <div className="border border-fl-border bg-fl-surface">
           <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
             <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-              Related Topics
+              {t('relatedTopics')}
             </span>
           </div>
           <div className="px-6 py-5 flex flex-wrap gap-2">
@@ -252,7 +255,7 @@ export default function GrammarDetailPage({
         href="/grammar"
         className="inline-block font-mono text-fl-label text-fl-muted-2 tracking-widest uppercase hover:text-fl-fg transition-colors"
       >
-        ← Back to Grammar
+        ← {t('backLink')}
       </Link>
     </div>
   )

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -195,7 +195,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 }`}
             >
               <span className="text-fl-label text-fl-muted-4">●</span>
-              ADMIN
+              {tNav('admin')}
             </Link>
           )}
         </nav>

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -206,7 +206,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             {user?.displayName || user?.username}
           </p>
           <p className="text-fl-label font-mono text-fl-muted-4 mb-3">@{user?.username}</p>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.5</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.6</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -312,7 +312,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             )}
             <div className="border-t border-fl-border mx-5 mt-2 pt-3">
               <p className="font-mono text-fl-label text-fl-muted-4 mb-1">@{user?.username}</p>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.5</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.6</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/app/(app)/phrasebook/page.tsx
+++ b/frontend/src/app/(app)/phrasebook/page.tsx
@@ -25,6 +25,7 @@ function CategoryCard({
   cat: typeof phrasebookCategories[0]
   registerFilter: Register | 'All'
 }) {
+  const t = useTranslations('phrasebook')
   const phrases =
     registerFilter === 'All'
       ? cat.phrases
@@ -57,7 +58,7 @@ function CategoryCard({
               </p>
               <div className="flex items-center gap-1 shrink-0">
                 <span className={`font-mono text-fl-label tracking-widest uppercase ${REGISTER_COLORS[phrase.register]}`}>
-                  {phrase.register}
+                  {t(phrase.register)}
                 </span>
                 <CopyButton text={phrase.english} />
               </div>

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -9,17 +9,12 @@ import { useThemeStore } from '@/store/theme'
 import { useRouter } from 'next/navigation'
 import { ExternalLink } from 'lucide-react'
 
-const LANGUAGES = [
-  { code: 'es', name: 'Spanish' },
-  { code: 'fr', name: 'French' },
-  { code: 'pt', name: 'Portuguese' },
-  { code: 'de', name: 'German' },
-  { code: 'it', name: 'Italian' },
-]
+const LANGUAGES = ['es', 'fr', 'pt', 'de', 'it'] as const
 
 export default function SettingsPage() {
   const t = useTranslations('settings')
   const tCommon = useTranslations('common')
+  const tLang = useTranslations('languages')
   const user = useAuthStore((s) => s.user)
   const setUser = useAuthStore((s) => s.setUser)
   const logout = useAuthStore((s) => s.logout)
@@ -153,8 +148,8 @@ export default function SettingsPage() {
             onChange={(e) => setNativeLanguage(e.target.value)}
             className="w-full bg-fl-bg border border-fl-border px-4 py-3 font-mono text-sm text-fl-fg focus:outline-none focus:border-fl-border-2 transition-colors appearance-none"
           >
-            {LANGUAGES.map((l) => (
-              <option key={l.code} value={l.code}>{l.name}</option>
+            {LANGUAGES.map((code) => (
+              <option key={code} value={code}>{tLang(code)}</option>
             ))}
           </select>
         </div>

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -138,6 +138,9 @@ export default function SettingsPage() {
               type={field.type}
               value={field.value}
               onChange={(e) => field.onChange(e.target.value)}
+              autoCorrect={field.type === 'email' ? 'off' : undefined}
+              autoCapitalize={field.type === 'email' ? 'none' : undefined}
+              spellCheck={field.type === 'email' ? false : undefined}
               className="w-full bg-fl-bg border border-fl-border px-4 py-3 font-mono text-sm text-fl-fg focus:outline-none focus:border-fl-border-2 transition-colors"
             />
           </div>
@@ -189,6 +192,9 @@ export default function SettingsPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder={t('newPasswordPlaceholder')}
+            autoCorrect="off"
+            autoCapitalize="none"
+            spellCheck={false}
             className="w-full bg-fl-bg border border-fl-border px-4 py-3 font-mono text-sm text-fl-fg placeholder:text-fl-muted-4 focus:outline-none focus:border-fl-border-2 transition-colors"
           />
         </div>
@@ -201,6 +207,9 @@ export default function SettingsPage() {
             onChange={(e) => setConfirmPassword(e.target.value)}
             placeholder={t('confirmPasswordPlaceholder')}
             disabled={!password}
+            autoCorrect="off"
+            autoCapitalize="none"
+            spellCheck={false}
             className="w-full bg-fl-bg border border-fl-border px-4 py-3 font-mono text-sm text-fl-fg placeholder:text-fl-muted-4 focus:outline-none focus:border-fl-border-2 disabled:opacity-30 transition-colors"
           />
         </div>

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from '@/store/auth'
 
 function LoginForm() {
   const t = useTranslations('auth.login')
+  const tCommon = useTranslations('common')
   const router = useRouter()
   const searchParams = useSearchParams()
   const registered = searchParams.get('registered') === 'true'
@@ -65,7 +66,7 @@ function LoginForm() {
         <div className="flex flex-col items-center mb-10">
           <Image src="/logo.png" alt="FreeLingo" width={80} height={80} className="mb-4" />
           <h1 className="font-mono text-xl font-bold tracking-widest text-fl-fg uppercase">FreeLingo</h1>
-          <p className="font-mono text-fl-caption text-fl-muted-2 tracking-widest uppercase mt-1">self-hosted language learning</p>
+          <p className="font-mono text-fl-caption text-fl-muted-2 tracking-widest uppercase mt-1">{tCommon('tagline')}</p>
         </div>
 
         <div className="border border-fl-border bg-fl-surface p-8">

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -94,6 +94,9 @@ function LoginForm() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 autoComplete="username"
+                autoCorrect="off"
+                autoCapitalize="none"
+                spellCheck={false}
                 className="w-full bg-fl-bg border border-fl-border px-4 py-3 font-mono text-sm text-fl-fg focus:outline-none focus:border-fl-border-2 transition-colors"
               />
             </div>
@@ -105,6 +108,9 @@ function LoginForm() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   autoComplete="current-password"
+                  autoCorrect="off"
+                  autoCapitalize="none"
+                  spellCheck={false}
                   className="w-full bg-fl-bg border border-fl-border px-4 py-3 pr-11 font-mono text-sm text-fl-fg focus:outline-none focus:border-fl-border-2 transition-colors"
                 />
                 <button

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -106,6 +106,9 @@ function RegisterForm() {
                   onChange={(e) => field.onChange(e.target.value)}
                   required={field.required}
                   placeholder={'placeholder' in field ? field.placeholder : undefined}
+                  autoCorrect={field.type === 'email' || field.type === 'password' ? 'off' : undefined}
+                  autoCapitalize={field.type === 'email' || field.type === 'password' ? 'none' : undefined}
+                  spellCheck={field.type === 'email' || field.type === 'password' ? false : undefined}
                   className="w-full bg-fl-bg border border-fl-border px-4 py-3 font-mono text-sm text-fl-fg placeholder:text-fl-muted-4 focus:outline-none focus:border-fl-border-2 transition-colors"
                 />
               </div>

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -6,16 +6,12 @@ import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { apiFetch } from '@/lib/api'
 
-const LANGUAGES = [
-  { code: 'es', name: 'Spanish' },
-  { code: 'fr', name: 'French' },
-  { code: 'pt', name: 'Portuguese' },
-  { code: 'de', name: 'German' },
-  { code: 'it', name: 'Italian' },
-]
+const LANGUAGES = ['es', 'fr', 'pt', 'de', 'it'] as const
 
 function RegisterForm() {
   const t = useTranslations('auth.register')
+  const tLang = useTranslations('languages')
+  const tCommon = useTranslations('common')
   const router = useRouter()
   const searchParams = useSearchParams()
   const invite = searchParams.get('invite')
@@ -74,7 +70,7 @@ function RegisterForm() {
         <div className="flex flex-col items-center mb-10">
           <Image src="/logo.png" alt="FreeLingo" width={80} height={80} className="mb-4" />
           <h1 className="font-mono text-xl font-bold tracking-widest text-fl-fg uppercase">FreeLingo</h1>
-          <p className="font-mono text-fl-caption text-fl-muted-2 tracking-widest uppercase mt-1">self-hosted language learning</p>
+          <p className="font-mono text-fl-caption text-fl-muted-2 tracking-widest uppercase mt-1">{tCommon('tagline')}</p>
         </div>
 
         <div className="border border-fl-border bg-fl-surface p-8">
@@ -121,8 +117,8 @@ function RegisterForm() {
                 onChange={(e) => setNativeLanguage(e.target.value)}
                 className="w-full bg-fl-bg border border-fl-border px-4 py-3 font-mono text-sm text-fl-fg focus:outline-none focus:border-fl-border-2 transition-colors appearance-none"
               >
-                {LANGUAGES.map((l) => (
-                  <option key={l.code} value={l.code}>{l.name}</option>
+                {LANGUAGES.map((code) => (
+                  <option key={code} value={code}>{tLang(code)}</option>
                 ))}
               </select>
             </div>

--- a/frontend/src/components/assessment/AdaptiveQuizCard.tsx
+++ b/frontend/src/components/assessment/AdaptiveQuizCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useTranslations } from 'next-intl'
 import type { AssessmentQuestion } from '@/data/assessment-bank'
 
 interface Props {
@@ -15,12 +16,13 @@ export default function AdaptiveQuizCard({
   totalQuestions,
   onAnswer,
 }: Props) {
+  const t = useTranslations('assessment')
   const progress = Math.round((questionNumber / totalQuestions) * 100)
 
-  const skillLabel: Record<string, string> = {
-    grammar: 'Grammar',
-    vocabulary: 'Vocabulary',
-    reading: 'Reading',
+  const skillLabelMap: Record<string, string> = {
+    grammar: t('skills.grammar'),
+    vocabulary: t('skills.vocabulary'),
+    reading: t('skills.reading'),
   }
 
   return (
@@ -31,7 +33,7 @@ export default function AdaptiveQuizCard({
           <div className="flex items-center gap-2">
             <span className="text-fl-label text-fl-muted-3">●</span>
             <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-              Step 2 / 3 — Question {questionNumber} / {totalQuestions}
+              {t('step2', { questionNumber, totalQuestions })}
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -39,7 +41,7 @@ export default function AdaptiveQuizCard({
               {question.difficulty}
             </span>
             <span className="font-mono text-fl-hint tracking-widest text-fl-muted-3 uppercase border border-fl-border px-2 py-1">
-              {skillLabel[question.skill] ?? question.skill}
+              {skillLabelMap[question.skill] ?? question.skill}
             </span>
           </div>
         </div>

--- a/frontend/src/components/assessment/BeginnerGate.tsx
+++ b/frontend/src/components/assessment/BeginnerGate.tsx
@@ -1,27 +1,31 @@
 'use client'
 
+import { useTranslations } from 'next-intl'
+
 interface Props {
   onBeginner: () => void
   onHasExperience: () => void
 }
 
 export default function BeginnerGate({ onBeginner, onHasExperience }: Props) {
+  const t = useTranslations('assessment')
+
   return (
     <div className="flex min-h-[60vh] items-center justify-center p-6">
       <div className="w-full max-w-md border border-fl-border bg-fl-surface">
         <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
           <span className="text-fl-label text-fl-muted-3">●</span>
           <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-            Step 1 / 3 — Your level
+            {t('step1')}
           </span>
         </div>
         <div className="p-8 space-y-6">
           <div className="text-center space-y-2">
             <p className="font-mono text-fl-body text-fl-fg">
-              Have you studied English before?
+              {t('studiedBefore')}
             </p>
             <p className="font-mono text-fl-label text-fl-muted-3">
-              This helps us start the quiz at the right level.
+              {t('studiedBeforeHint')}
             </p>
           </div>
           <div className="flex flex-col gap-3">
@@ -30,9 +34,9 @@ export default function BeginnerGate({ onBeginner, onHasExperience }: Props) {
               className="w-full border border-fl-border text-fl-muted-2 font-mono text-xs tracking-widest uppercase py-4 hover:border-fl-border-2 hover:text-fl-fg transition-colors text-left px-5"
             >
               <span className="text-fl-muted-3 mr-3">○</span>
-              I am a complete beginner
+              {t('beginnerOption')}
               <span className="block text-fl-hint text-fl-muted-3 normal-case mt-1 ml-6">
-                I will start at A1 — no quiz needed.
+                {t('beginnerOptionHint')}
               </span>
             </button>
             <button
@@ -40,9 +44,9 @@ export default function BeginnerGate({ onBeginner, onHasExperience }: Props) {
               className="w-full bg-fl-fg text-fl-bg font-mono text-xs font-bold tracking-widest uppercase py-4 hover:bg-fl-fg-bright transition-colors text-left px-5"
             >
               <span className="mr-3">●</span>
-              Yes, I have some experience
+              {t('hasExperienceOption')}
               <span className="block text-fl-hint font-normal normal-case mt-1 ml-6 opacity-70">
-                I will take a short adaptive quiz (≈12 questions).
+                {t('hasExperienceOptionHint')}
               </span>
             </button>
           </div>

--- a/frontend/src/components/assessment/DurationSelector.tsx
+++ b/frontend/src/components/assessment/DurationSelector.tsx
@@ -1,55 +1,26 @@
 'use client'
 
+import { useTranslations } from 'next-intl'
+
 export interface DurationOption {
   weeks: number
   daysPerWeek: number
-  label: string
-  sublabel: string
-  approxLessons: string
-  intensity: string
+  intensity: 'intensive' | 'standard' | 'relaxed' | 'very_relaxed'
 }
 
 export const DURATION_OPTIONS: DurationOption[] = [
-  {
-    weeks: 4,
-    daysPerWeek: 5,
-    label: '4 weeks',
-    sublabel: 'Intensive',
-    approxLessons: '~20 lessons',
-    intensity: 'intensive',
-  },
-  {
-    weeks: 8,
-    daysPerWeek: 5,
-    label: '8 weeks',
-    sublabel: 'Standard',
-    approxLessons: '~40 lessons',
-    intensity: 'standard',
-  },
-  {
-    weeks: 12,
-    daysPerWeek: 4,
-    label: '12 weeks',
-    sublabel: 'Relaxed',
-    approxLessons: '~48 lessons',
-    intensity: 'relaxed',
-  },
-  {
-    weeks: 16,
-    daysPerWeek: 3,
-    label: '16 weeks',
-    sublabel: 'Very relaxed',
-    approxLessons: '~48 lessons',
-    intensity: 'very_relaxed',
-  },
+  { weeks: 4, daysPerWeek: 5, intensity: 'intensive' },
+  { weeks: 8, daysPerWeek: 5, intensity: 'standard' },
+  { weeks: 12, daysPerWeek: 4, intensity: 'relaxed' },
+  { weeks: 16, daysPerWeek: 3, intensity: 'very_relaxed' },
 ]
 
 export const GOAL_OPTIONS = [
-  { id: 'grammar', label: 'Grammar' },
-  { id: 'vocabulary', label: 'Vocabulary' },
-  { id: 'reading', label: 'Reading' },
-  { id: 'writing', label: 'Writing' },
-  { id: 'conversation', label: 'Conversation' },
+  { id: 'grammar' },
+  { id: 'vocabulary' },
+  { id: 'reading' },
+  { id: 'writing' },
+  { id: 'conversation' },
 ]
 
 interface Props {
@@ -73,7 +44,16 @@ export default function DurationSelector({
   cefr_level,
   loading,
 }: Props) {
+  const t = useTranslations('assessment')
+  const tCommon = useTranslations('common')
   const selected = DURATION_OPTIONS.find((o) => o.weeks === selectedWeeks) ?? DURATION_OPTIONS[2]
+
+  const intensityMap: Record<string, string> = {
+    intensive: t('intensity.intensive'),
+    standard: t('intensity.standard'),
+    relaxed: t('intensity.relaxed'),
+    very_relaxed: t('intensity.veryRelaxed'),
+  }
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center p-6">
@@ -81,7 +61,7 @@ export default function DurationSelector({
         <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-border">
           <span className="text-fl-label text-fl-muted-3">●</span>
           <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-            Step 3 / 3 — Your programme
+            {t('step3')}
           </span>
         </div>
 
@@ -89,7 +69,7 @@ export default function DurationSelector({
           {/* Duration */}
           <div>
             <p className="font-mono text-fl-hint tracking-widest text-fl-muted-3 uppercase mb-3">
-              How many weeks for level {cefr_level}?
+              {t('howManyWeeks', { cefr_level })}
             </p>
             <div className="grid grid-cols-2 gap-2">
               {DURATION_OPTIONS.map((opt) => (
@@ -102,19 +82,19 @@ export default function DurationSelector({
                     }`}
                 >
                   <p className="font-mono text-xs font-bold tracking-widest uppercase">
-                    {opt.label}
+                    {t('nWeeks', { count: opt.weeks })}
                   </p>
                   <p
                     className={`font-mono text-fl-hint mt-0.5 ${selectedWeeks === opt.weeks ? 'opacity-70' : 'text-fl-muted-3'
                       }`}
                   >
-                    {opt.sublabel} · {opt.approxLessons}
+                    {intensityMap[opt.intensity]} · {t('approxLessons', { count: opt.weeks * opt.daysPerWeek })}
                   </p>
                   <p
                     className={`font-mono text-fl-hint mt-0.5 ${selectedWeeks === opt.weeks ? 'opacity-60' : 'text-fl-muted-3'
                       }`}
                   >
-                    {opt.daysPerWeek} days/week
+                    {t('daysPerWeek', { count: opt.daysPerWeek })}
                   </p>
                 </button>
               ))}
@@ -124,7 +104,7 @@ export default function DurationSelector({
           {/* Goals */}
           <div>
             <p className="font-mono text-fl-hint tracking-widest text-fl-muted-3 uppercase mb-3">
-              Main goals (select all that apply)
+              {t('mainGoals')}
             </p>
             <div className="flex flex-wrap gap-2">
               {GOAL_OPTIONS.map((g) => (
@@ -136,7 +116,7 @@ export default function DurationSelector({
                       : 'border-fl-border text-fl-muted-2 hover:border-fl-border-2 hover:text-fl-fg'
                     }`}
                 >
-                  {selectedGoals.includes(g.id) ? '✓ ' : ''}{g.label}
+                  {selectedGoals.includes(g.id) ? '✓ ' : ''}{t(`goals.${g.id as 'grammar' | 'vocabulary' | 'reading' | 'writing' | 'conversation'}`)}
                 </button>
               ))}
             </div>
@@ -144,15 +124,17 @@ export default function DurationSelector({
 
           {/* Summary */}
           <div className="border border-fl-border px-4 py-3 font-mono text-fl-label text-fl-muted-1 tracking-wide space-y-1">
-            <p>Level: <span className="text-fl-fg font-bold">{cefr_level}</span></p>
+            <p>{t('summaryLevel')}: <span className="text-fl-fg font-bold">{cefr_level}</span></p>
             <p>
-              Duration: <span className="text-fl-fg">{selected.weeks} weeks</span>
+              {t('summaryDuration')}: <span className="text-fl-fg">{t('nWeeks', { count: selected.weeks })}</span>
               {' · '}
-              <span className="text-fl-fg">{selected.daysPerWeek} days/week</span>
+              <span className="text-fl-fg">{t('daysPerWeek', { count: selected.daysPerWeek })}</span>
             </p>
             <p>
-              Goals: <span className="text-fl-fg">
-                {selectedGoals.length > 0 ? selectedGoals.join(', ') : 'none selected'}
+              {t('summaryGoals')}: <span className="text-fl-fg">
+                {selectedGoals.length > 0
+                  ? selectedGoals.map((g) => t(`goals.${g as 'grammar' | 'vocabulary' | 'reading' | 'writing' | 'conversation'}`)).join(', ')
+                  : t('noneSelected')}
               </span>
             </p>
           </div>
@@ -162,14 +144,14 @@ export default function DurationSelector({
               onClick={onBack}
               className="flex-1 border border-fl-border text-fl-muted-2 font-mono text-xs tracking-widest uppercase py-3 hover:border-fl-border-2 hover:text-fl-fg transition-colors"
             >
-              ← Back
+              ← {tCommon('back')}
             </button>
             <button
               onClick={onConfirm}
               disabled={loading || selectedGoals.length === 0}
               className="flex-[2] bg-fl-fg text-fl-bg font-mono text-xs font-bold tracking-widest uppercase py-3 hover:bg-fl-fg-bright disabled:opacity-40 transition-colors"
             >
-              {loading ? '— Building plan…' : '— Start my plan →'}
+              {loading ? `— ${t('buildingPlan')}` : `— ${t('startMyPlan')} →`}
             </button>
           </div>
         </div>

--- a/frontend/src/components/plan/LevelTestBanner.tsx
+++ b/frontend/src/components/plan/LevelTestBanner.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
 
 interface Props {
   planId: number
@@ -8,6 +9,7 @@ interface Props {
 }
 
 export default function LevelTestBanner({ planId, level }: Props) {
+  const t = useTranslations('plan')
   const router = useRouter()
 
   return (
@@ -15,23 +17,21 @@ export default function LevelTestBanner({ planId, level }: Props) {
       <div className="flex items-center gap-2 px-6 py-4 border-b border-fl-fg/20">
         <span className="font-mono text-fl-label text-fl-fg">⊞</span>
         <span className="font-mono text-fl-label tracking-widest text-fl-fg uppercase">
-          Level {level} Complete — Take the Level Test
+          {t('levelComplete', { level })}
         </span>
       </div>
       <div className="p-6 space-y-4">
         <p className="font-mono text-fl-label text-fl-muted-1 leading-relaxed">
-          You have finished all units for level{' '}
-          <span className="text-fl-fg font-bold">{level}</span>. Take the level
-          completion test to confirm your progress and unlock the next level.
+          {t('levelCompleteDesc', { level })}
         </p>
         <p className="font-mono text-fl-hint text-fl-muted-3">
-          The test takes approximately 20 minutes and covers grammar, vocabulary, and reading.
+          {t('levelCompleteHint')}
         </p>
         <button
           onClick={() => router.push(`/assessment/level-test?plan=${planId}`)}
           className="bg-fl-fg text-fl-bg font-mono text-xs font-bold tracking-widest uppercase px-6 py-3 hover:bg-fl-fg-bright transition-colors"
         >
-          — Begin Level Test →
+          — {t('beginLevelTest')} →
         </button>
       </div>
     </div>

--- a/frontend/src/components/plan/UnitCard.tsx
+++ b/frontend/src/components/plan/UnitCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { type ReactNode } from 'react'
+import { useTranslations } from 'next-intl'
 
 interface UnitStatus {
   completed: boolean
@@ -36,6 +37,7 @@ export default function UnitCard({
   status,
   onClick,
 }: Props) {
+  const t = useTranslations('plan')
   const barWidth = Math.round(competency * 100)
 
   return (
@@ -48,7 +50,7 @@ export default function UnitCard({
           ? 'border-fl-fg bg-fl-surface hover:bg-fl-surface-2'
           : 'border-fl-border bg-fl-surface hover:border-fl-border-2'
         }`}
-      aria-label={`Unit ${index + 1}: ${title}`}
+      aria-label={t('unitAriaLabel', { index: index + 1, title })}
     >
       {/* Top bar: status + index + title */}
       <div className="flex items-center gap-3 px-4 py-3">
@@ -69,16 +71,16 @@ export default function UnitCard({
           </div>
           <div className="flex items-center gap-3 mt-1">
             <span className="font-mono text-fl-hint text-fl-muted-3">
-              {lessonCount} lessons
+              {t('nLessons', { count: lessonCount })}
             </span>
             {grammarCount > 0 && (
               <span className="font-mono text-fl-hint text-fl-muted-3">
-                {grammarCount} grammar
+                {t('nGrammar', { count: grammarCount })}
               </span>
             )}
             {status.isLevelTest && (
               <span className="font-mono text-fl-hint text-fl-muted-2 uppercase tracking-widest border border-fl-border px-1.5 py-0.5">
-                Level Test
+                {t('levelTestLabel')}
               </span>
             )}
           </div>

--- a/frontend/src/components/plan/UnitDrawer.tsx
+++ b/frontend/src/components/plan/UnitDrawer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import { useTranslations } from 'next-intl'
 import type { CurriculumUnit } from '@/data/curriculum'
 
 interface Lesson {
@@ -20,6 +21,8 @@ interface Props {
 }
 
 export default function UnitDrawer({ unit, lessons, onClose, onStartLesson }: Props) {
+  const t = useTranslations('plan')
+  const tCommon = useTranslations('common')
   const ref = useRef<HTMLDivElement>(null)
 
   // Close on outside click
@@ -41,13 +44,13 @@ export default function UnitDrawer({ unit, lessons, onClose, onStartLesson }: Pr
   }, [onClose])
 
   const lessonTypeLabel: Record<string, string> = {
-    grammar: 'Grammar',
-    vocabulary: 'Vocabulary',
-    reading: 'Reading',
-    writing: 'Writing',
-    conversation: 'Conversation',
-    review: 'Review',
-    level_test: 'Level Test',
+    grammar: t('lessonTypes.grammar'),
+    vocabulary: t('lessonTypes.vocabulary'),
+    reading: t('lessonTypes.reading'),
+    writing: t('lessonTypes.writing'),
+    conversation: t('lessonTypes.conversation'),
+    review: t('lessonTypes.review'),
+    level_test: t('lessonTypes.level_test'),
   }
 
   return (
@@ -60,14 +63,14 @@ export default function UnitDrawer({ unit, lessons, onClose, onStartLesson }: Pr
         <div className="flex items-center justify-between px-6 py-4 border-b border-fl-border sticky top-0 bg-fl-surface z-10">
           <div>
             <span className="font-mono text-fl-hint tracking-widest text-fl-muted-3 uppercase">
-              {unit.level} · Unit
+              {unit.level} · {t('unitLabel')}
             </span>
             <p className="font-mono text-fl-body text-fl-fg mt-0.5">{unit.title}</p>
           </div>
           <button
             onClick={onClose}
             className="font-mono text-fl-muted-3 hover:text-fl-fg transition-colors text-lg leading-none"
-            aria-label="Close drawer"
+            aria-label={tCommon('close')}
           >
             ✕
           </button>
@@ -77,7 +80,7 @@ export default function UnitDrawer({ unit, lessons, onClose, onStartLesson }: Pr
         {unit.grammar_points.length > 0 && (
           <div className="px-6 py-4 border-b border-fl-border">
             <p className="font-mono text-fl-hint tracking-widest text-fl-muted-3 uppercase mb-2">
-              Grammar covered
+              {t('grammarCovered')}
             </p>
             <div className="flex flex-wrap gap-1.5">
               {unit.grammar_points.map((gp) => (
@@ -97,7 +100,7 @@ export default function UnitDrawer({ unit, lessons, onClose, onStartLesson }: Pr
           {lessons.length === 0 ? (
             <div className="px-6 py-6">
               <p className="font-mono text-fl-label text-fl-muted-3">
-                No lessons scheduled yet for this unit.
+                {t('noLessons')}
               </p>
             </div>
           ) : (
@@ -114,7 +117,7 @@ export default function UnitDrawer({ unit, lessons, onClose, onStartLesson }: Pr
                     {lesson.title}
                   </p>
                   <p className="font-mono text-fl-hint text-fl-muted-3">
-                    Week {lesson.week}, Day {lesson.day} ·{' '}
+                    {t('weekDay', { week: lesson.week, day: lesson.day })} ·{' '}
                     {lessonTypeLabel[lesson.lesson_type] ?? lesson.lesson_type}
                   </p>
                 </div>
@@ -123,7 +126,7 @@ export default function UnitDrawer({ unit, lessons, onClose, onStartLesson }: Pr
                     onClick={() => onStartLesson(lesson.id!)}
                     className="font-mono text-fl-hint tracking-widest text-fl-muted-2 uppercase border border-fl-border px-3 py-1.5 hover:border-fl-border-2 hover:text-fl-fg transition-colors shrink-0"
                   >
-                    Start
+                    {tCommon('start')}
                   </button>
                 )}
               </div>
@@ -137,7 +140,7 @@ export default function UnitDrawer({ unit, lessons, onClose, onStartLesson }: Pr
             onClick={onClose}
             className="w-full border border-fl-border text-fl-muted-2 font-mono text-xs tracking-widest uppercase py-3 hover:border-fl-border-2 hover:text-fl-fg transition-colors"
           >
-            Close
+            {tCommon('close')}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ui/AudioPlayer.tsx
+++ b/frontend/src/components/ui/AudioPlayer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { useAuthStore } from '@/store/auth'
 
 interface AudioPlayerProps {
@@ -16,6 +17,7 @@ export function AudioPlayer({ text, voice, size = 'sm', className = '' }: AudioP
   const [state, setState] = useState<PlayerState>('idle')
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const accessToken = useAuthStore((s) => s.accessToken)
+  const t = useTranslations('audioPlayer')
 
   async function handleClick() {
     if (state === 'loading') return
@@ -80,8 +82,8 @@ export function AudioPlayer({ text, voice, size = 'sm', className = '' }: AudioP
   return (
     <button
       onClick={handleClick}
-      title={state === 'playing' ? 'Stop' : 'Listen'}
-      aria-label={state === 'playing' ? 'Stop audio' : 'Listen to pronunciation'}
+      title={state === 'playing' ? t('stop') : t('listen')}
+      aria-label={state === 'playing' ? t('ariaStop') : t('ariaListen')}
       className={`border font-mono tracking-widest uppercase transition-colors ${colorClass} ${sizeClass} ${className}`}
     >
       {label}

--- a/frontend/src/components/ui/VoiceRecorder.tsx
+++ b/frontend/src/components/ui/VoiceRecorder.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { useAuthStore } from '@/store/auth'
 
 interface VoiceRecorderProps {
@@ -21,6 +22,7 @@ export function VoiceRecorder({
   const [state, setState] = useState<RecorderState>('idle')
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const accessToken = useAuthStore((s) => s.accessToken)
+  const t = useTranslations('voiceRecorder')
 
   async function handleClick() {
     if (disabled) return
@@ -79,10 +81,10 @@ export function VoiceRecorder({
   }
 
   const label =
-    state === 'recording'    ? '■ Stop' :
-    state === 'transcribing' ? '… Processing' :
-    state === 'error'        ? '✕ Error' :
-    '● Record'
+    state === 'recording'    ? `■ ${t('stop')}` :
+    state === 'transcribing' ? `… ${t('processing')}` :
+    state === 'error'        ? `✕ ${t('error')}` :
+    `● ${t('record')}`
 
   const colorClass =
     state === 'recording'    ? 'border-fl-error/60 text-fl-error-fg animate-pulse' :
@@ -95,7 +97,7 @@ export function VoiceRecorder({
     <button
       onClick={handleClick}
       disabled={disabled && state === 'idle'}
-      aria-label={state === 'recording' ? 'Stop recording' : 'Start recording'}
+      aria-label={state === 'recording' ? t('ariaStop') : t('ariaRecord')}
       className={`border px-3 py-2 font-mono text-xs tracking-widest uppercase transition-colors ${colorClass} ${className}`}
     >
       {label}

--- a/messages/de.json
+++ b/messages/de.json
@@ -24,7 +24,8 @@
     "complete": "Abgeschlossen",
     "checking": "Wird geprüft...",
     "backToDashboard": "Zurück zum Dashboard",
-    "tagline": "selbst gehostetes Sprachenlernen"
+    "tagline": "selbst gehostetes Sprachenlernen",
+    "close": "Schließen"
   },
   "nav": {
     "home": "Startseite",
@@ -205,7 +206,45 @@
         "back": "Zurück zum Plan"
       }
     },
-    "suggestedLevel": "Vorgeschlagen {aiLevel} — Plan verwendet {selectedLevel}"
+    "suggestedLevel": "Vorgeschlagen {aiLevel} — Plan verwendet {selectedLevel}",
+    "step1": "Schritt 1 / 3 — Dein Niveau",
+    "step2": "Schritt 2 / 3 — Frage {questionNumber} / {totalQuestions}",
+    "step3": "Schritt 3 / 3 — Dein Programm",
+    "studiedBefore": "Hast du schon Englisch gelernt?",
+    "studiedBeforeHint": "Das hilft uns, das Quiz auf dem richtigen Niveau zu beginnen.",
+    "beginnerOption": "Ich bin ein kompletter Anfänger",
+    "beginnerOptionHint": "Ich beginne bei A1 — kein Quiz nötig.",
+    "hasExperienceOption": "Ja, ich habe etwas Erfahrung",
+    "hasExperienceOptionHint": "Ich mache ein kurzes adaptives Quiz (≈12 Fragen).",
+    "skills": {
+      "grammar": "Grammatik",
+      "vocabulary": "Vokabular",
+      "reading": "Lesen"
+    },
+    "howManyWeeks": "Wie viele Wochen für Niveau {cefr_level}?",
+    "nWeeks": "{count} Wochen",
+    "intensity": {
+      "intensive": "Intensiv",
+      "standard": "Standard",
+      "relaxed": "Entspannt",
+      "veryRelaxed": "Sehr entspannt"
+    },
+    "approxLessons": "~{count} Lektionen",
+    "daysPerWeek": "{count} Tage/Woche",
+    "mainGoals": "Hauptziele (alle zutreffenden auswählen)",
+    "goals": {
+      "grammar": "Grammatik",
+      "vocabulary": "Vokabular",
+      "reading": "Lesen",
+      "writing": "Schreiben",
+      "conversation": "Gespräch"
+    },
+    "summaryLevel": "Niveau",
+    "summaryDuration": "Dauer",
+    "summaryGoals": "Ziele",
+    "noneSelected": "keine ausgewählt",
+    "buildingPlan": "Plan wird erstellt…",
+    "startMyPlan": "Meinen Plan starten"
   },
   "plan": {
     "title": "Mein Plan",
@@ -224,7 +263,28 @@
     "duration": "Dauer",
     "unitsLabel": "Einheiten",
     "noUnitsForLevel": "Keine Einheiten für Niveau {level} verfügbar",
-    "takeAssessmentArrow": "Bewertung starten →"
+    "takeAssessmentArrow": "Bewertung starten →",
+    "unitLabel": "Einheit",
+    "grammarCovered": "Behandelte Grammatik",
+    "noLessons": "Noch keine Lektionen für diese Einheit geplant.",
+    "weekDay": "Woche {week}, Tag {day}",
+    "lessonTypes": {
+      "grammar": "Grammatik",
+      "vocabulary": "Vokabular",
+      "reading": "Lesen",
+      "writing": "Schreiben",
+      "conversation": "Gespräch",
+      "review": "Wiederholung",
+      "level_test": "Stufentest"
+    },
+    "levelComplete": "Niveau {level} abgeschlossen — Mache den Stufentest",
+    "levelCompleteDesc": "Du hast alle Einheiten für Niveau {level} abgeschlossen. Mache den Stufentest, um deinen Fortschritt zu bestätigen und das nächste Niveau freizuschalten.",
+    "levelCompleteHint": "Der Test dauert etwa 20 Minuten und umfasst Grammatik, Vokabular und Lesen.",
+    "beginLevelTest": "Stufentest starten",
+    "nLessons": "{count} Lektionen",
+    "nGrammar": "{count} Grammatik",
+    "levelTestLabel": "Stufentest",
+    "unitAriaLabel": "Einheit {index}: {title}"
   },
   "lesson": {
     "loading": "Lektion wird geladen...",
@@ -336,6 +396,8 @@
     "commonMistakes": "Häufige Fehler",
     "relatedTopics": "Verwandte Themen",
     "backToGrammar": "Grammatik",
+    "explanation": "Erklärung",
+    "backLink": "Zurück zur Grammatik",
     "notFound": "Thema nicht gefunden."
   },
   "vocabulary": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -23,7 +23,8 @@
     "score": "Punktzahl",
     "complete": "Abgeschlossen",
     "checking": "Wird geprüft...",
-    "backToDashboard": "Zurück zum Dashboard"
+    "backToDashboard": "Zurück zum Dashboard",
+    "tagline": "selbst gehostetes Sprachenlernen"
   },
   "nav": {
     "home": "Startseite",
@@ -459,5 +460,26 @@
     "tapToStart": "Sprich wenn du bereit bist",
     "you": "Du",
     "assistant": "FreeLingo"
+  },
+  "voiceRecorder": {
+    "record": "Aufnehmen",
+    "stop": "Stopp",
+    "processing": "Verarbeitung",
+    "error": "Fehler",
+    "ariaRecord": "Aufnahme starten",
+    "ariaStop": "Aufnahme stoppen"
+  },
+  "audioPlayer": {
+    "listen": "Anhören",
+    "stop": "Stopp",
+    "ariaListen": "Aussprache anhören",
+    "ariaStop": "Audio stoppen"
+  },
+  "languages": {
+    "es": "Spanisch",
+    "fr": "Französisch",
+    "pt": "Portugiesisch",
+    "de": "Deutsch",
+    "it": "Italienisch"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -23,7 +23,8 @@
     "score": "Score",
     "complete": "Complete",
     "checking": "Checking...",
-    "backToDashboard": "Back to Dashboard"
+    "backToDashboard": "Back to Dashboard",
+    "tagline": "self-hosted language learning"
   },
   "nav": {
     "home": "Home",
@@ -459,5 +460,26 @@
     "tapToStart": "Speak when ready",
     "you": "You",
     "assistant": "FreeLingo"
+  },
+  "voiceRecorder": {
+    "record": "Record",
+    "stop": "Stop",
+    "processing": "Processing",
+    "error": "Error",
+    "ariaRecord": "Start recording",
+    "ariaStop": "Stop recording"
+  },
+  "audioPlayer": {
+    "listen": "Listen",
+    "stop": "Stop",
+    "ariaListen": "Listen to pronunciation",
+    "ariaStop": "Stop audio"
+  },
+  "languages": {
+    "es": "Spanish",
+    "fr": "French",
+    "pt": "Portuguese",
+    "de": "German",
+    "it": "Italian"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -24,7 +24,8 @@
     "complete": "Complete",
     "checking": "Checking...",
     "backToDashboard": "Back to Dashboard",
-    "tagline": "self-hosted language learning"
+    "tagline": "self-hosted language learning",
+    "close": "Close"
   },
   "nav": {
     "home": "Home",
@@ -205,7 +206,45 @@
         "back": "Back to Plan"
       }
     },
-    "suggestedLevel": "Suggested {aiLevel} — plan will use {selectedLevel}"
+    "suggestedLevel": "Suggested {aiLevel} — plan will use {selectedLevel}",
+    "step1": "Step 1 / 3 — Your level",
+    "step2": "Step 2 / 3 — Question {questionNumber} / {totalQuestions}",
+    "step3": "Step 3 / 3 — Your programme",
+    "studiedBefore": "Have you studied English before?",
+    "studiedBeforeHint": "This helps us start the quiz at the right level.",
+    "beginnerOption": "I am a complete beginner",
+    "beginnerOptionHint": "I will start at A1 — no quiz needed.",
+    "hasExperienceOption": "Yes, I have some experience",
+    "hasExperienceOptionHint": "I will take a short adaptive quiz (≈12 questions).",
+    "skills": {
+      "grammar": "Grammar",
+      "vocabulary": "Vocabulary",
+      "reading": "Reading"
+    },
+    "howManyWeeks": "How many weeks for level {cefr_level}?",
+    "nWeeks": "{count} weeks",
+    "intensity": {
+      "intensive": "Intensive",
+      "standard": "Standard",
+      "relaxed": "Relaxed",
+      "veryRelaxed": "Very relaxed"
+    },
+    "approxLessons": "~{count} lessons",
+    "daysPerWeek": "{count} days/week",
+    "mainGoals": "Main goals (select all that apply)",
+    "goals": {
+      "grammar": "Grammar",
+      "vocabulary": "Vocabulary",
+      "reading": "Reading",
+      "writing": "Writing",
+      "conversation": "Conversation"
+    },
+    "summaryLevel": "Level",
+    "summaryDuration": "Duration",
+    "summaryGoals": "Goals",
+    "noneSelected": "none selected",
+    "buildingPlan": "Building plan…",
+    "startMyPlan": "Start my plan"
   },
   "plan": {
     "title": "My Plan",
@@ -224,7 +263,28 @@
     "duration": "Duration",
     "unitsLabel": "Units",
     "noUnitsForLevel": "No units available for level {level}",
-    "takeAssessmentArrow": "Take Assessment →"
+    "takeAssessmentArrow": "Take Assessment →",
+    "unitLabel": "Unit",
+    "grammarCovered": "Grammar covered",
+    "noLessons": "No lessons scheduled yet for this unit.",
+    "weekDay": "Week {week}, Day {day}",
+    "lessonTypes": {
+      "grammar": "Grammar",
+      "vocabulary": "Vocabulary",
+      "reading": "Reading",
+      "writing": "Writing",
+      "conversation": "Conversation",
+      "review": "Review",
+      "level_test": "Level Test"
+    },
+    "levelComplete": "Level {level} Complete — Take the Level Test",
+    "levelCompleteDesc": "You have finished all units for level {level}. Take the level completion test to confirm your progress and unlock the next level.",
+    "levelCompleteHint": "The test takes approximately 20 minutes and covers grammar, vocabulary, and reading.",
+    "beginLevelTest": "Begin Level Test",
+    "nLessons": "{count} lessons",
+    "nGrammar": "{count} grammar",
+    "levelTestLabel": "Level Test",
+    "unitAriaLabel": "Unit {index}: {title}"
   },
   "lesson": {
     "loading": "Loading lesson...",
@@ -336,6 +396,8 @@
     "commonMistakes": "Common Mistakes",
     "relatedTopics": "Related Topics",
     "backToGrammar": "Grammar Reference",
+    "explanation": "Explanation",
+    "backLink": "Back to Grammar",
     "notFound": "Topic not found."
   },
   "vocabulary": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -24,7 +24,8 @@
     "complete": "Completado",
     "checking": "Comprobando...",
     "backToDashboard": "Volver al inicio",
-    "tagline": "aprendizaje de idiomas autoalojado"
+    "tagline": "aprendizaje de idiomas autoalojado",
+    "close": "Cerrar"
   },
   "nav": {
     "home": "Inicio",
@@ -205,7 +206,45 @@
         "back": "Volver al plan"
       }
     },
-    "suggestedLevel": "Sugerido {aiLevel} — el plan usará {selectedLevel}"
+    "suggestedLevel": "Sugerido {aiLevel} — el plan usará {selectedLevel}",
+    "step1": "Paso 1 / 3 — Tu nivel",
+    "step2": "Paso 2 / 3 — Pregunta {questionNumber} / {totalQuestions}",
+    "step3": "Paso 3 / 3 — Tu programa",
+    "studiedBefore": "¿Has estudiado inglés antes?",
+    "studiedBeforeHint": "Esto nos ayuda a empezar el cuestionario en el nivel adecuado.",
+    "beginnerOption": "Soy principiante absoluto",
+    "beginnerOptionHint": "Empezaré en A1 — sin cuestionario.",
+    "hasExperienceOption": "Sí, tengo algo de experiencia",
+    "hasExperienceOptionHint": "Haré un breve cuestionario adaptativo (≈12 preguntas).",
+    "skills": {
+      "grammar": "Gramática",
+      "vocabulary": "Vocabulario",
+      "reading": "Lectura"
+    },
+    "howManyWeeks": "¿Cuántas semanas para el nivel {cefr_level}?",
+    "nWeeks": "{count} semanas",
+    "intensity": {
+      "intensive": "Intensivo",
+      "standard": "Estándar",
+      "relaxed": "Relajado",
+      "veryRelaxed": "Muy relajado"
+    },
+    "approxLessons": "~{count} lecciones",
+    "daysPerWeek": "{count} días/semana",
+    "mainGoals": "Objetivos principales (selecciona todos los que apliquen)",
+    "goals": {
+      "grammar": "Gramática",
+      "vocabulary": "Vocabulario",
+      "reading": "Lectura",
+      "writing": "Escritura",
+      "conversation": "Conversación"
+    },
+    "summaryLevel": "Nivel",
+    "summaryDuration": "Duración",
+    "summaryGoals": "Objetivos",
+    "noneSelected": "ninguno seleccionado",
+    "buildingPlan": "Creando plan…",
+    "startMyPlan": "Empezar mi plan"
   },
   "plan": {
     "title": "Mi Plan",
@@ -224,7 +263,28 @@
     "duration": "Duración",
     "unitsLabel": "Unidades",
     "noUnitsForLevel": "No hay unidades disponibles para el nivel {level}",
-    "takeAssessmentArrow": "Hacer evaluación →"
+    "takeAssessmentArrow": "Hacer evaluación →",
+    "unitLabel": "Unidad",
+    "grammarCovered": "Gramática cubierta",
+    "noLessons": "No hay lecciones programadas para esta unidad.",
+    "weekDay": "Semana {week}, Día {day}",
+    "lessonTypes": {
+      "grammar": "Gramática",
+      "vocabulary": "Vocabulario",
+      "reading": "Lectura",
+      "writing": "Escritura",
+      "conversation": "Conversación",
+      "review": "Repaso",
+      "level_test": "Test de nivel"
+    },
+    "levelComplete": "Nivel {level} completado — Haz el test de nivel",
+    "levelCompleteDesc": "Has completado todas las unidades del nivel {level}. Haz el test de finalización de nivel para confirmar tu progreso y desbloquear el siguiente.",
+    "levelCompleteHint": "El test dura aproximadamente 20 minutos y cubre gramática, vocabulario y lectura.",
+    "beginLevelTest": "Empezar el test de nivel",
+    "nLessons": "{count} lecciones",
+    "nGrammar": "{count} gramática",
+    "levelTestLabel": "Test de nivel",
+    "unitAriaLabel": "Unidad {index}: {title}"
   },
   "lesson": {
     "loading": "Cargando lección…",
@@ -336,6 +396,8 @@
     "commonMistakes": "Errores comunes",
     "relatedTopics": "Temas relacionados",
     "backToGrammar": "Gramática",
+    "explanation": "Explicación",
+    "backLink": "Volver a gramática",
     "notFound": "Tema no encontrado."
   },
   "vocabulary": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -23,7 +23,8 @@
     "score": "Puntuación",
     "complete": "Completado",
     "checking": "Comprobando...",
-    "backToDashboard": "Volver al inicio"
+    "backToDashboard": "Volver al inicio",
+    "tagline": "aprendizaje de idiomas autoalojado"
   },
   "nav": {
     "home": "Inicio",
@@ -459,5 +460,26 @@
     "tapToStart": "Habla cuando estés listo",
     "you": "Tú",
     "assistant": "FreeLingo"
+  },
+  "voiceRecorder": {
+    "record": "Grabar",
+    "stop": "Detener",
+    "processing": "Procesando",
+    "error": "Error",
+    "ariaRecord": "Iniciar grabación",
+    "ariaStop": "Detener grabación"
+  },
+  "audioPlayer": {
+    "listen": "Escuchar",
+    "stop": "Detener",
+    "ariaListen": "Escuchar pronunciación",
+    "ariaStop": "Detener audio"
+  },
+  "languages": {
+    "es": "Español",
+    "fr": "Francés",
+    "pt": "Portugués",
+    "de": "Alemán",
+    "it": "Italiano"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -24,7 +24,8 @@
     "complete": "Terminé",
     "checking": "Vérification...",
     "backToDashboard": "Retour au tableau de bord",
-    "tagline": "apprentissage des langues auto-hébergé"
+    "tagline": "apprentissage des langues auto-hébergé",
+    "close": "Fermer"
   },
   "nav": {
     "home": "Accueil",
@@ -205,7 +206,45 @@
         "back": "Retour au plan"
       }
     },
-    "suggestedLevel": "Suggéré {aiLevel} — le plan utilisera {selectedLevel}"
+    "suggestedLevel": "Suggéré {aiLevel} — le plan utilisera {selectedLevel}",
+    "step1": "Étape 1 / 3 — Votre niveau",
+    "step2": "Étape 2 / 3 — Question {questionNumber} / {totalQuestions}",
+    "step3": "Étape 3 / 3 — Votre programme",
+    "studiedBefore": "Avez-vous déjà étudié l'anglais ?",
+    "studiedBeforeHint": "Cela nous aide à commencer le quiz au bon niveau.",
+    "beginnerOption": "Je suis débutant complet",
+    "beginnerOptionHint": "Je commencerai à A1 — pas de quiz nécessaire.",
+    "hasExperienceOption": "Oui, j'ai un peu d'expérience",
+    "hasExperienceOptionHint": "Je passerai un court quiz adaptatif (≈12 questions).",
+    "skills": {
+      "grammar": "Grammaire",
+      "vocabulary": "Vocabulaire",
+      "reading": "Lecture"
+    },
+    "howManyWeeks": "Combien de semaines pour le niveau {cefr_level} ?",
+    "nWeeks": "{count} semaines",
+    "intensity": {
+      "intensive": "Intensif",
+      "standard": "Standard",
+      "relaxed": "Détendu",
+      "veryRelaxed": "Très détendu"
+    },
+    "approxLessons": "~{count} leçons",
+    "daysPerWeek": "{count} jours/semaine",
+    "mainGoals": "Objectifs principaux (sélectionnez tout ce qui s'applique)",
+    "goals": {
+      "grammar": "Grammaire",
+      "vocabulary": "Vocabulaire",
+      "reading": "Lecture",
+      "writing": "Écriture",
+      "conversation": "Conversation"
+    },
+    "summaryLevel": "Niveau",
+    "summaryDuration": "Durée",
+    "summaryGoals": "Objectifs",
+    "noneSelected": "aucun sélectionné",
+    "buildingPlan": "Création du plan…",
+    "startMyPlan": "Démarrer mon plan"
   },
   "plan": {
     "title": "Mon Plan",
@@ -224,7 +263,28 @@
     "duration": "Durée",
     "unitsLabel": "Unités",
     "noUnitsForLevel": "Aucune unité disponible pour le niveau {level}",
-    "takeAssessmentArrow": "Passer l'évaluation →"
+    "takeAssessmentArrow": "Passer l'évaluation →",
+    "unitLabel": "Unité",
+    "grammarCovered": "Grammaire couverte",
+    "noLessons": "Aucune leçon programmée pour cette unité.",
+    "weekDay": "Semaine {week}, Jour {day}",
+    "lessonTypes": {
+      "grammar": "Grammaire",
+      "vocabulary": "Vocabulaire",
+      "reading": "Lecture",
+      "writing": "Écriture",
+      "conversation": "Conversation",
+      "review": "Révision",
+      "level_test": "Test de niveau"
+    },
+    "levelComplete": "Niveau {level} terminé — Passez le test de niveau",
+    "levelCompleteDesc": "Vous avez terminé toutes les unités du niveau {level}. Passez le test de fin de niveau pour confirmer vos progrès et débloquer le niveau suivant.",
+    "levelCompleteHint": "Le test dure environ 20 minutes et couvre la grammaire, le vocabulaire et la lecture.",
+    "beginLevelTest": "Commencer le test de niveau",
+    "nLessons": "{count} leçons",
+    "nGrammar": "{count} grammaire",
+    "levelTestLabel": "Test de niveau",
+    "unitAriaLabel": "Unité {index} : {title}"
   },
   "lesson": {
     "loading": "Chargement de la leçon...",
@@ -336,6 +396,8 @@
     "commonMistakes": "Erreurs fréquentes",
     "relatedTopics": "Thèmes associés",
     "backToGrammar": "Grammaire",
+    "explanation": "Explication",
+    "backLink": "Retour à la grammaire",
     "notFound": "Thème introuvable."
   },
   "vocabulary": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -23,7 +23,8 @@
     "score": "Score",
     "complete": "Terminé",
     "checking": "Vérification...",
-    "backToDashboard": "Retour au tableau de bord"
+    "backToDashboard": "Retour au tableau de bord",
+    "tagline": "apprentissage des langues auto-hébergé"
   },
   "nav": {
     "home": "Accueil",
@@ -459,5 +460,26 @@
     "tapToStart": "Parlez quand vous êtes prêt",
     "you": "Vous",
     "assistant": "FreeLingo"
+  },
+  "voiceRecorder": {
+    "record": "Enregistrer",
+    "stop": "Arrêter",
+    "processing": "Traitement",
+    "error": "Erreur",
+    "ariaRecord": "Commencer l'enregistrement",
+    "ariaStop": "Arrêter l'enregistrement"
+  },
+  "audioPlayer": {
+    "listen": "Écouter",
+    "stop": "Arrêter",
+    "ariaListen": "Écouter la prononciation",
+    "ariaStop": "Arrêter l'audio"
+  },
+  "languages": {
+    "es": "Espagnol",
+    "fr": "Français",
+    "pt": "Portugais",
+    "de": "Allemand",
+    "it": "Italien"
   }
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -24,7 +24,8 @@
     "complete": "Completato",
     "checking": "Controllo in corso...",
     "backToDashboard": "Torna alla dashboard",
-    "tagline": "apprendimento linguistico self-hosted"
+    "tagline": "apprendimento linguistico self-hosted",
+    "close": "Chiudi"
   },
   "nav": {
     "home": "Home",
@@ -205,7 +206,45 @@
         "back": "Torna al piano"
       }
     },
-    "suggestedLevel": "Suggerito {aiLevel} — il piano utilizzerà {selectedLevel}"
+    "suggestedLevel": "Suggerito {aiLevel} — il piano utilizzerà {selectedLevel}",
+    "step1": "Passo 1 / 3 — Il tuo livello",
+    "step2": "Passo 2 / 3 — Domanda {questionNumber} / {totalQuestions}",
+    "step3": "Passo 3 / 3 — Il tuo programma",
+    "studiedBefore": "Hai studiato inglese in precedenza?",
+    "studiedBeforeHint": "Questo ci aiuta a iniziare il quiz al livello giusto.",
+    "beginnerOption": "Sono un principiante assoluto",
+    "beginnerOptionHint": "Inizierò da A1 — nessun quiz necessario.",
+    "hasExperienceOption": "Sì, ho un po' di esperienza",
+    "hasExperienceOptionHint": "Farò un breve quiz adattivo (≈12 domande).",
+    "skills": {
+      "grammar": "Grammatica",
+      "vocabulary": "Vocabolario",
+      "reading": "Lettura"
+    },
+    "howManyWeeks": "Quante settimane per il livello {cefr_level}?",
+    "nWeeks": "{count} settimane",
+    "intensity": {
+      "intensive": "Intensivo",
+      "standard": "Standard",
+      "relaxed": "Rilassato",
+      "veryRelaxed": "Molto rilassato"
+    },
+    "approxLessons": "~{count} lezioni",
+    "daysPerWeek": "{count} giorni/settimana",
+    "mainGoals": "Obiettivi principali (seleziona tutti quelli applicabili)",
+    "goals": {
+      "grammar": "Grammatica",
+      "vocabulary": "Vocabolario",
+      "reading": "Lettura",
+      "writing": "Scrittura",
+      "conversation": "Conversazione"
+    },
+    "summaryLevel": "Livello",
+    "summaryDuration": "Durata",
+    "summaryGoals": "Obiettivi",
+    "noneSelected": "nessuno selezionato",
+    "buildingPlan": "Creazione piano…",
+    "startMyPlan": "Inizia il mio piano"
   },
   "plan": {
     "title": "Il Mio Piano",
@@ -224,7 +263,28 @@
     "duration": "Durata",
     "unitsLabel": "Unità",
     "noUnitsForLevel": "Nessuna unità disponibile per il livello {level}",
-    "takeAssessmentArrow": "Fai la valutazione →"
+    "takeAssessmentArrow": "Fai la valutazione →",
+    "unitLabel": "Unità",
+    "grammarCovered": "Grammatica trattata",
+    "noLessons": "Nessuna lezione programmata per questa unità.",
+    "weekDay": "Settimana {week}, Giorno {day}",
+    "lessonTypes": {
+      "grammar": "Grammatica",
+      "vocabulary": "Vocabolario",
+      "reading": "Lettura",
+      "writing": "Scrittura",
+      "conversation": "Conversazione",
+      "review": "Ripasso",
+      "level_test": "Test di livello"
+    },
+    "levelComplete": "Livello {level} completato — Fai il test di livello",
+    "levelCompleteDesc": "Hai completato tutte le unità del livello {level}. Fai il test di completamento del livello per confermare i tuoi progressi e sbloccare il livello successivo.",
+    "levelCompleteHint": "Il test dura circa 20 minuti e copre grammatica, vocabolario e lettura.",
+    "beginLevelTest": "Inizia il test di livello",
+    "nLessons": "{count} lezioni",
+    "nGrammar": "{count} grammatica",
+    "levelTestLabel": "Test di livello",
+    "unitAriaLabel": "Unità {index}: {title}"
   },
   "lesson": {
     "loading": "Caricamento lezione...",
@@ -336,6 +396,8 @@
     "commonMistakes": "Errori comuni",
     "relatedTopics": "Argomenti correlati",
     "backToGrammar": "Grammatica",
+    "explanation": "Spiegazione",
+    "backLink": "Torna alla grammatica",
     "notFound": "Argomento non trovato."
   },
   "vocabulary": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -23,7 +23,8 @@
     "score": "Punteggio",
     "complete": "Completato",
     "checking": "Controllo in corso...",
-    "backToDashboard": "Torna alla dashboard"
+    "backToDashboard": "Torna alla dashboard",
+    "tagline": "apprendimento linguistico self-hosted"
   },
   "nav": {
     "home": "Home",
@@ -459,5 +460,26 @@
     "tapToStart": "Parla quando sei pronto",
     "you": "Tu",
     "assistant": "FreeLingo"
+  },
+  "voiceRecorder": {
+    "record": "Registra",
+    "stop": "Ferma",
+    "processing": "Elaborazione",
+    "error": "Errore",
+    "ariaRecord": "Avvia registrazione",
+    "ariaStop": "Ferma registrazione"
+  },
+  "audioPlayer": {
+    "listen": "Ascolta",
+    "stop": "Ferma",
+    "ariaListen": "Ascolta la pronuncia",
+    "ariaStop": "Ferma audio"
+  },
+  "languages": {
+    "es": "Spagnolo",
+    "fr": "Francese",
+    "pt": "Portoghese",
+    "de": "Tedesco",
+    "it": "Italiano"
   }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -23,7 +23,8 @@
     "score": "Pontuação",
     "complete": "Completo",
     "checking": "Verificando...",
-    "backToDashboard": "Voltar ao painel"
+    "backToDashboard": "Voltar ao painel",
+    "tagline": "aprendizado de idiomas auto-hospedado"
   },
   "nav": {
     "home": "Início",
@@ -459,5 +460,26 @@
     "tapToStart": "Fale quando estiver pronto",
     "you": "Você",
     "assistant": "FreeLingo"
+  },
+  "voiceRecorder": {
+    "record": "Gravar",
+    "stop": "Parar",
+    "processing": "Processando",
+    "error": "Erro",
+    "ariaRecord": "Iniciar gravação",
+    "ariaStop": "Parar gravação"
+  },
+  "audioPlayer": {
+    "listen": "Ouvir",
+    "stop": "Parar",
+    "ariaListen": "Ouvir pronúncia",
+    "ariaStop": "Parar áudio"
+  },
+  "languages": {
+    "es": "Espanhol",
+    "fr": "Francês",
+    "pt": "Português",
+    "de": "Alemão",
+    "it": "Italiano"
   }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -24,7 +24,8 @@
     "complete": "Completo",
     "checking": "Verificando...",
     "backToDashboard": "Voltar ao painel",
-    "tagline": "aprendizado de idiomas auto-hospedado"
+    "tagline": "aprendizado de idiomas auto-hospedado",
+    "close": "Fechar"
   },
   "nav": {
     "home": "Início",
@@ -224,7 +225,28 @@
     "duration": "Duração",
     "unitsLabel": "Unidades",
     "noUnitsForLevel": "Nenhuma unidade disponível para o nível {level}",
-    "takeAssessmentArrow": "Fazer avaliação →"
+    "takeAssessmentArrow": "Fazer avaliação →",
+    "unitLabel": "Unidade",
+    "grammarCovered": "Gramática abordada",
+    "noLessons": "Nenhuma aula agendada para esta unidade.",
+    "weekDay": "Semana {week}, Dia {day}",
+    "lessonTypes": {
+      "grammar": "Gramática",
+      "vocabulary": "Vocabulário",
+      "reading": "Leitura",
+      "writing": "Escrita",
+      "conversation": "Conversa",
+      "review": "Revisão",
+      "level_test": "Teste de nível"
+    },
+    "levelComplete": "Nível {level} completo — Faça o teste de nível",
+    "levelCompleteDesc": "Concluiu todas as unidades do nível {level}. Faça o teste de conclusão de nível para confirmar o seu progresso e desbloquear o próximo nível.",
+    "levelCompleteHint": "O teste demora cerca de 20 minutos e abrange gramática, vocabulário e leitura.",
+    "beginLevelTest": "Começar o teste de nível",
+    "nLessons": "{count} aulas",
+    "nGrammar": "{count} gramática",
+    "levelTestLabel": "Teste de nível",
+    "unitAriaLabel": "Unidade {index}: {title}"
   },
   "lesson": {
     "loading": "Carregando aula...",
@@ -336,6 +358,8 @@
     "commonMistakes": "Erros comuns",
     "relatedTopics": "Tópicos relacionados",
     "backToGrammar": "Gramática",
+    "explanation": "Explicação",
+    "backLink": "Voltar à gramática",
     "notFound": "Tópico não encontrado."
   },
   "vocabulary": {

--- a/specs/readme.instructions.md
+++ b/specs/readme.instructions.md
@@ -41,7 +41,7 @@ The README follows this exact structure in order:
 Current badges shown in README:
 
 ```markdown
-![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)
+![License](https://img.shields.io/badge/license-AGPL%20v3-blue?style=flat-square)
 ![Next.js](https://img.shields.io/badge/next.js-16-black?style=flat-square)
 ![Python](https://img.shields.io/badge/python-3.12-blue?style=flat-square)
 ![Self-hosted](https://img.shields.io/badge/self--hosted-yes-orange?style=flat-square)

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.2.5**
+**1.2.6**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request delivers a significant internationalization (i18n) upgrade, improves accessibility and usability, and updates the project's licensing. All previously hardcoded UI strings are now fully translatable across six languages, and language display names are dynamically resolved. The project also transitions from the Apache 2.0 License to the GNU Affero General Public License v3 (AGPL v3). Additionally, input fields for email and password are now configured to prevent mobile keyboard interference, and the conversation mode is updated to always respond in English.

**Internationalization and Localization:**
* Full i18n coverage added for all previously hardcoded UI strings, with translations across six locale files (`en`, `es`, `fr`, `pt`, `de`, `it`). Components such as `grammar/[slug]/page.tsx`, `UnitDrawer.tsx`, `LevelTestBanner.tsx`, `UnitCard.tsx`, `BeginnerGate.tsx`, `AdaptiveQuizCard.tsx`, `DurationSelector.tsx`, `VoiceRecorder.tsx`, `AudioPlayer.tsx`, admin, register, and settings pages now use `useTranslations` for all display text. Language display names are resolved at render time via translation keys. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R31) [frontend/src/app/(app)/grammar/[slug]/page.tsxR6](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043R6), [frontend/src/app/(app)/grammar/[slug]/page.tsxR69-R70](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043R69-R70), [frontend/src/app/(app)/grammar/[slug]/page.tsxL85-R88](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L85-R88), [frontend/src/app/(app)/grammar/[slug]/page.tsxL98-R101](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L98-R101), [frontend/src/app/(app)/grammar/[slug]/page.tsxL119-R122](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L119-R122), [frontend/src/app/(app)/grammar/[slug]/page.tsxL131-R134](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L131-R134), [frontend/src/app/(app)/grammar/[slug]/page.tsxL160-R163](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L160-R163), [frontend/src/app/(app)/grammar/[slug]/page.tsxL179-R182](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L179-R182), [frontend/src/app/(app)/grammar/[slug]/page.tsxL200-R203](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L200-R203), [frontend/src/app/(app)/grammar/[slug]/page.tsxL232-R235](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L232-R235), [frontend/src/app/(app)/grammar/[slug]/page.tsxL255-R258](diffhunk://#diff-4dec96346cd98bed247d027d7c36b255c20dfad4d18060335f9e81164d524043L255-R258), [[2]](diffhunk://#diff-284f6e50bfbe196253a33dc10dc57918da86a764e38c65f39b367547ae27a594L19-R23) [[3]](diffhunk://#diff-284f6e50bfbe196253a33dc10dc57918da86a764e38c65f39b367547ae27a594L197-R195) [[4]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0L12-R17) [[5]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0L153-R152) [[6]](diffhunk://#diff-b46177d6f652ddef5d091660e9b2b5d611a3e3abc15e8e1508ce11c9c2fa9248R28) [[7]](diffhunk://#diff-b46177d6f652ddef5d091660e9b2b5d611a3e3abc15e8e1508ce11c9c2fa9248L60-R61) [[8]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L198-R198)

**Licensing:**
* Project license changed from Apache 2.0 to GNU Affero General Public License v3 (AGPL v3). All documentation, badges, and contributor agreements updated to reflect this change. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L241-R241) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L73-R73)

**Conversation Mode and Backend Logic:**
* Conversation mode updated: the LLM now always responds in English, regardless of the student's language. If a student uses another language, the tutor replies in English and encourages them to try in English. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R31) [[2]](diffhunk://#diff-a74cc90ba3ba21401e80b96a69172fec6d9dc592ed1b1ca142b455251033c9d0R31)

**Accessibility and Usability:**
* Email, password, and confirm-password fields across login, register, settings, and admin pages now have `autoCorrect="off"`, `autoCapitalize="none"`, and `spellCheck={false}` to prevent mobile keyboards from corrupting typed values. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R31) [[2]](diffhunk://#diff-284f6e50bfbe196253a33dc10dc57918da86a764e38c65f39b367547ae27a594R184-R186) [[3]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0R136-R138) [[4]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0R190-R192)

**Other Improvements:**
* `DurationOption` interface cleaned up and `GOAL_OPTIONS` simplified; all display strings are now derived from translations at render time.
* App version bumped to 1.2.6 in UI and changelog. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L209-R209) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L315-R315) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R31)