### PR TITLE
feature: phase 4 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-05-04
+
+### Added
+- Phase 4 — Target language selection: `english_variant` field replaced by generic `target_language` (BCP-47) across the entire stack
+- Alembic migration `0007_target_language.py`: adds `target_language` column to `users` and `study_plans`, back-fills existing rows (`american` → `en-US`, `british` → `en-GB`), drops `english_variant`
+- `SUPPORTED_TARGET_LANGUAGES: set[str] = {"en-US", "en-GB"}` constant in `app/schemas/auth.py`; new `target_language` field with validator on `RegisterRequest` and `UserUpdateRequest`; `UserResponse` exposes `target_language`
+- `app/services/language_helpers.py`: `get_english_variant(target_language)` and `get_iso639(target_language)` helpers used across the service layer
+- `target_language` column added to `StudyPlan` model and recorded from the authenticated user at `POST /api/assessment/complete`
+- Auto-login on register: `POST /api/auth/register` now issues a JWT access token and sets the refresh token cookie in the same response, returning `{ id, username, role, access_token }`
+- `/onboarding` page (`src/app/(auth)/onboarding/page.tsx`): post-registration screen where new users choose their English variant; placed in the `(auth)` route group (no sidebar)
+- `TargetLanguageSelector` component (`src/components/onboarding/TargetLanguageSelector.tsx`): flag cards for `en-US` and `en-GB` with i18n display names and descriptions
+- `src/lib/target-languages.ts`: `SUPPORTED_TARGET_LANGUAGES` constant on the frontend — single place to add a new target language
+- i18n namespaces `onboarding` (`headline`, `subtitle`, `cta`) and `targetLanguages` (`en-US`, `en-US-description`, `en-GB`, `en-GB-description`) added to all six locale files (en, es, fr, pt, de, it)
+
+### Changed
+- Register flow: after successful registration the frontend stores the returned `access_token` and redirects to `/onboarding` instead of `/login?registered=true`
+- `FlashcardGenerateRequest`: `native_language` field removed — the backend now always reads `native_language` from the authenticated user's profile, ignoring any client-supplied value
+- `ConversationPipeline`: `native_language` and `english_variant` (derived from `target_language`) are now injected into `CONVERSATION_SYSTEM_PROMPT`; previously both were absent from the voice tutor context
+- All services (`lesson_generator`, `flashcard_sm2`, `chat`, `conversation_pipeline`, `stt_service`) updated to consume `target_language` instead of `english_variant`; STT `language` parameter derived dynamically via `get_iso639`
+- Settings page: English variant selector removed — the choice is made during onboarding and is not surfaced in the UI afterwards
+
+### Removed
+- i18n keys `settings.englishVariant`, `settings.american`, `settings.british`, `auth.register.englishVariant`, `auth.register.american`, `auth.register.british` removed from all locale files
+
 ## [1.2.6] - 2026-05-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ the frontend never calls them directly.
 freelingo/
 ├── assets/             # Logos and static assets
 ├── backend/            # FastAPI (Python)
-├── docker/             # Custom Dockerfiles (e.g. Kokoro with Blackwell GPU support)
 ├── docs/               # GitHub Pages landing site
 ├── frontend/           # Next.js (React)
 ├── messages/           # i18n translation files (en, es, fr, pt, de, it)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ freelingo/
 | 1+    | Learning Resources Hub | ✅ Complete         |
 | 2     | Local TTS + STT        | ✅ Complete         |
 | 3     | Real-time conversation | ✅ Complete         |
-| 4     | Multi-language support | 🚧 In development   |
+| 4     | Multi-language support | ✅ Complete         |
 
 ## Quick start
 
@@ -124,6 +124,7 @@ The first registered user becomes admin automatically.
 - [phase-1-plus.instructions.md](specs/phase-1-plus.instructions.md) — Phase 1+: Learning Resources Hub — Grammar Reference, Vocabulary Hub, Phrasebook, Skills Tracker, Level Completion Test
 - [phase-2-tts-stt.instructions.md](specs/phase-2-tts-stt.instructions.md) — Phase 2: Kokoro TTS, faster-whisper STT, pronunciation exercises
 - [phase-3-conversation.instructions.md](specs/phase-3-conversation.instructions.md) — Phase 3: WebSocket voice pipeline, VAD, barge-in
+- [phase-4-target-language.instructions.md](specs/phase-4-target-language.instructions.md) — Phase 4: target_language (BCP-47), onboarding flow, auto-login on register
 - [rate-limiting.instructions.md](specs/rate-limiting.instructions.md) — slowapi-based rate limits per-endpoint, self-hosted defaults
 - [readme.instructions.md](specs/readme.instructions.md) — README structure, badges, and update guidelines
 - [roadmap.instructions.md](specs/roadmap.instructions.md) — Development roadmap with milestones and completion criteria
@@ -135,7 +136,7 @@ The first registered user becomes admin automatically.
 - The recommended model for Ollama is `gemma3:12b`. It can be changed in `.env`.
 - The backend acts as a proxy for Ollama/TTS/STT calls so the frontend never talks directly to those services.
 - The `LLM_PROVIDER` field controls the LLM provider: `ollama` (local, recommended), `openai`, `anthropic`, or `deepseek`.
-- The target language is always **English**. During registration, the user's native language is asked for flashcard translations and tutor feedback.
+- The target language is always **English** (`en-US` American English or `en-GB` British English). The variant is chosen on the `/onboarding` screen immediately after registration. The user's native language is asked during registration and is used only for flashcard translations and tutor feedback.
 
 ## Reverse proxy requirement (real-time conversation)
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -243,3 +243,21 @@ async def update_me(
     await db.commit()
     await db.refresh(current_user)
     return current_user
+
+
+@router.delete("/me", status_code=204)
+async def delete_me(
+    request: Request,
+    response: Response,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    redis: Redis = Depends(get_redis),
+):
+    if current_user.role == "admin":
+        raise HTTPException(status_code=403, detail="Admin accounts cannot be self-deleted")
+    token = request.cookies.get("refresh_token")
+    if token:
+        await redis.delete(f"refresh:{token}")
+    response.delete_cookie("refresh_token")
+    await db.delete(current_user)
+    await db.commit()

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -20,6 +20,7 @@ interface TodayLessonItem {
 export default function DashboardPage() {
   const t = useTranslations('dashboard')
   const tNav = useTranslations('nav')
+  const tPlan = useTranslations('plan')
   const user = useAuthStore((s) => s.user)
   const { streak, xp, skills, todayLessons, completedToday, setProgress, setTodayLessons } =
     useProgressStore()
@@ -99,7 +100,7 @@ export default function DashboardPage() {
               {skillEntries.map(([skill, value]) => (
                 <div key={skill}>
                   <div className="flex justify-between mb-1">
-                    <span className="font-mono text-fl-label tracking-widest text-fl-muted-1 uppercase">{skill}</span>
+                    <span className="font-mono text-fl-label tracking-widest text-fl-muted-1 uppercase">{tPlan(`lessonTypes.${skill}`)}</span>
                     <span className="font-mono text-fl-label text-fl-muted-2">{Math.round((value as number) * 100)}%</span>
                   </div>
                   <div className="h-px bg-fl-border w-full">
@@ -126,7 +127,7 @@ export default function DashboardPage() {
                   <div>
                     <p className="font-mono text-xs text-fl-fg">{lesson.title}</p>
                     <p className="font-mono text-fl-label text-fl-muted-2 uppercase tracking-wider mt-0.5">
-                      {lesson.lessonType} · {lesson.estimatedMinutes}min
+                      {tPlan(`lessonTypes.${lesson.lessonType}`)} · {lesson.estimatedMinutes}min
                     </p>
                   </div>
                   {lesson.id && completedToday.includes(lesson.id) ? (

--- a/frontend/src/app/(app)/grammar/page.tsx
+++ b/frontend/src/app/(app)/grammar/page.tsx
@@ -92,7 +92,7 @@ export default function GrammarIndexPage() {
         </div>
         <div className="px-6 py-5 space-y-4">
           <p className="font-mono text-xs text-fl-muted-2 leading-relaxed">
-            {grammarTopics.length} topics · A1 – C2 · No login required for browsing
+            {grammarTopics.length} topics · A1 – C2
           </p>
           {/* Search */}
           <input
@@ -132,7 +132,7 @@ export default function GrammarIndexPage() {
       {/* Results count when filtering */}
       {(search || activeCategory !== 'All') && (
         <p className="font-mono text-fl-label text-fl-muted-3">
-          {filtered.length} topic{filtered.length !== 1 ? 's' : ''} found
+          {t('topicsFound', { count: filtered.length })}
         </p>
       )}
 

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -206,7 +206,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             {user?.displayName || user?.username}
           </p>
           <p className="text-fl-label font-mono text-fl-muted-4 mb-3">@{user?.username}</p>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.6</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.0</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -312,7 +312,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             )}
             <div className="border-t border-fl-border mx-5 mt-2 pt-3">
               <p className="font-mono text-fl-label text-fl-muted-4 mb-1">@{user?.username}</p>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.2.6</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.0</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/app/(app)/phrasebook/page.tsx
+++ b/frontend/src/app/(app)/phrasebook/page.tsx
@@ -7,7 +7,7 @@ import type { CEFRLevel } from '@/data/grammar'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const CEFR_LEVELS: CEFRLevel[] = ['A1', 'A2', 'B1', 'B2']
+const CEFR_LEVELS: CEFRLevel[] = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2']
 const REGISTERS: Register[] = ['formal', 'neutral', 'informal']
 
 const REGISTER_COLORS: Record<Register, string> = {
@@ -129,7 +129,11 @@ export default function PhrasebookPage() {
         </div>
         <div className="px-6 py-5 space-y-4">
           <p className="font-mono text-xs text-fl-muted-2 leading-relaxed">
-            {phrasebookCategories.length} situations · {totalPhrases} phrases · A1 – B2
+            {t('statsLine', {
+              situationCount: phrasebookCategories.length,
+              phraseCount: totalPhrases,
+              range: `${CEFR_LEVELS[0]} – ${CEFR_LEVELS[CEFR_LEVELS.length - 1]}`,
+            })}
           </p>
 
           {/* Level filter */}
@@ -175,7 +179,7 @@ export default function PhrasebookPage() {
       {/* Results */}
       {(activeLevel !== 'All' || activeRegister !== 'All') && (
         <p className="font-mono text-fl-label text-fl-muted-3">
-          {filteredCategories.length} situation{filteredCategories.length !== 1 ? 's' : ''} shown
+          {t('situationsShown', { count: filteredCategories.length })}
         </p>
       )}
 

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/store/auth'
 import { useThemeStore } from '@/store/theme'
 import { useRouter } from 'next/navigation'
 import { ExternalLink } from 'lucide-react'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 
 const LANGUAGES = ['es', 'fr', 'pt', 'de', 'it'] as const
 
@@ -33,6 +34,9 @@ export default function SettingsPage() {
   const [convInactivityTimeout, setConvInactivityTimeout] = useState<60 | 180 | 300>(180)
   const [convMessage, setConvMessage] = useState<{ type: 'ok' | 'err'; text: string } | null>(null)
   const [savingConv, setSavingConv] = useState(false)
+
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   useEffect(() => {
     if (user) {
@@ -96,6 +100,17 @@ export default function SettingsPage() {
       setConvMessage({ type: 'err', text: err instanceof Error ? err.message : t('saveFailed') })
     } finally {
       setSavingConv(false)
+    }
+  }
+
+  async function handleDeleteAccount() {
+    setDeleting(true)
+    try {
+      await apiFetch('/api/auth/me', { method: 'DELETE' })
+      logout()
+      router.push('/login')
+    } catch {
+      setDeleting(false)
     }
   }
 
@@ -314,6 +329,26 @@ export default function SettingsPage() {
       >
         — {tCommon('logout')}
       </button>
+
+      {user?.role !== 'admin' && (
+        <button
+          onClick={() => setDeleteConfirm(true)}
+          disabled={deleting}
+          className="w-full font-mono text-fl-label tracking-widest text-fl-muted-2 border border-fl-border py-3 mt-2 uppercase hover:text-fl-error hover:border-fl-error/40 disabled:opacity-40 transition-colors"
+        >
+          — {t('deleteAccount')}
+        </button>
+      )}
+
+      <ConfirmDialog
+        open={deleteConfirm}
+        title={t('deleteAccountTitle')}
+        message={t('deleteAccountMessage')}
+        confirmLabel={t('deleteAccountConfirm')}
+        danger
+        onConfirm={handleDeleteAccount}
+        onCancel={() => setDeleteConfirm(false)}
+      />
     </div>
   )
 }

--- a/frontend/src/app/(app)/vocabulary/[setId]/page.tsx
+++ b/frontend/src/app/(app)/vocabulary/[setId]/page.tsx
@@ -97,7 +97,7 @@ export default function VocabularySetPage({
             {vocabSet.topic}
           </h1>
           <p className="font-mono text-fl-label text-fl-muted-3">
-            {vocabSet.words.length} words
+            {vocabSet.words.length} {t('words')}
           </p>
 
           {/* Add to flashcards */}

--- a/frontend/src/app/(app)/vocabulary/page.tsx
+++ b/frontend/src/app/(app)/vocabulary/page.tsx
@@ -70,7 +70,7 @@ export default function VocabularyIndexPage() {
         </div>
         <div className="px-6 py-5 space-y-4">
           <p className="font-mono text-xs text-fl-muted-2 leading-relaxed">
-            {vocabularySets.length} sets · {totalWords} words · {usedLevels[0]} – {usedLevels[usedLevels.length - 1]}
+            {vocabularySets.length} {t('sets')} · {totalWords} {t('words')} · {usedLevels[0]} – {usedLevels[usedLevels.length - 1]}
           </p>
           {/* Search */}
           <input

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -53,7 +53,15 @@ function RegisterForm() {
         })
         if (!res.ok) {
           const data = await res.json()
-          throw new Error(data.detail || t('error'))
+          let msg: string
+          if (typeof data.detail === 'string') {
+            msg = data.detail
+          } else if (Array.isArray(data.detail) && data.detail.length > 0) {
+            msg = (data.detail[0] as { msg?: string }).msg ?? t('error')
+          } else {
+            msg = t('error')
+          }
+          throw new Error(msg)
         }
         const data = await res.json()
         setTokens(data.access_token)

--- a/frontend/src/components/TargetLanguageSelector.tsx
+++ b/frontend/src/components/TargetLanguageSelector.tsx
@@ -19,7 +19,7 @@ export default function TargetLanguageSelector({ value, onChange }: Props) {
           key={lang.code}
           type="button"
           onClick={() => onChange(lang.code)}
-          className={`flex-1 flex items-center justify-center gap-2 py-3 font-mono text-xs tracking-widest uppercase border transition-colors ${
+          className={`flex-1 flex items-center justify-center gap-2 px-3 py-3 font-mono text-xs tracking-widest uppercase border transition-colors ${
             value === lang.code
               ? 'border-fl-accent bg-fl-accent text-fl-accent-fg'
               : 'border-fl-border text-fl-muted-2 hover:border-fl-border-2 hover:text-fl-fg'

--- a/frontend/src/data/en/grammar.ts
+++ b/frontend/src/data/en/grammar.ts
@@ -708,6 +708,32 @@ export const grammarTopics: GrammarTopic[] = [
     related: ['past-simple', 'modal-verbs'],
   },
   {
+    slug: 'used-to-would',
+    title: 'Used To & Would (Past Habits)',
+    level: 'B1',
+    category: 'Tenses',
+    summary: 'Describe past habits, repeated actions, and states that no longer exist using *used to* and *would*.',
+    explanation: `**Used to** describes past habits, repeated actions, or states that are no longer true.\n\n**Structure:** *subject + used to + base verb*\n- *I used to play football every weekend.* (past habit)\n- *She used to live in Madrid.* (past state)\n\n**Would** describes past repeated actions or habits (NOT states).\n\n**Structure:** *subject + would + base verb*\n- *Every summer, we would visit my grandparents.* (past habit)\n- ❌ *She would live in Madrid.* (wrong — states need "used to", not "would")\n\n**Key differences:**\n| | used to | would |\n|---|---|---|\n| Habits | ✓ | ✓ |\n| States | ✓ | ✗ |\n| Single past events | ✗ | ✗ |\n\n**Negatives and questions use "used to":**\n- *I didn't use to like coffee.* (note: "use to", not "used to", after "did")\n- *Did you use to play chess?*`,
+    rules: [
+      'Use "used to" for past habits AND past states that are no longer true.',
+      'Use "would" only for past repeated actions — never for past states (know, believe, live, be, etc.).',
+      'After "did/didn\'t", write "use to" (no -d): "Did you use to…?" / "I didn\'t use to…"',
+      'Neither "used to" nor "would" can describe a single, one-off past event — use the past simple.',
+      'Both imply contrast with the present: the situation has changed.',
+    ],
+    examples: [
+      { english: 'I used to hate vegetables, but now I love them.', note: 'past state — use "used to", not "would"' },
+      { english: 'Every Friday, we would go to the cinema together.', note: 'past repeated action — "would" is fine' },
+      { english: "She didn't use to speak English very well.", note: 'negative form — "use to" after "didn\'t"' },
+      { english: 'Did you use to have long hair?', note: 'question form — "use to" after "did"' },
+    ],
+    common_mistakes: [
+      { wrong: 'He would live in Paris when he was young.', correct: 'He used to live in Paris when he was young.', note: '"Would" cannot describe past states — use "used to".' },
+      { wrong: 'I didn\'t used to like jazz.', correct: 'I didn\'t use to like jazz.', note: 'The -d is carried by "did" — "use to" has no -d after auxiliaries.' },
+    ],
+    related: ['past-simple', 'past-perfect', 'reported-speech-basics'],
+  },
+  {
     slug: 'expressing-opinions',
     title: 'Expressing & Defending Opinions',
     level: 'B1',

--- a/frontend/src/data/en/phrasebook.ts
+++ b/frontend/src/data/en/phrasebook.ts
@@ -418,6 +418,44 @@ const complex_arguments_c1: PhrasebookCategory = {
   ],
 }
 
+const professional_networking_c1: PhrasebookCategory = {
+  id: 'professional_networking_c1',
+  level: 'C1',
+  situation: 'Professional Networking',
+  icon: '🤝',
+  phrases: [
+    { english: 'I believe we have some mutual connections.', context: 'Breaking the ice at a professional event', register: 'formal' },
+    { english: 'I\'ve been following your work on [topic] — it\'s really compelling.', context: 'Opening a conversation with a professional you admire', register: 'formal' },
+    { english: 'I\'d love to pick your brain about [subject] sometime.', context: 'Proposing an informal knowledge exchange', register: 'neutral' },
+    { english: 'Would you be open to a brief call to explore potential synergies?', context: 'Suggesting a follow-up meeting', register: 'formal' },
+    { english: 'I\'m currently working on [project] — it might align with what you\'re doing.', context: 'Finding common ground', register: 'neutral' },
+    { english: 'Could I connect you with [Name]? I think you\'d have a lot to discuss.', context: 'Making an introduction', register: 'formal' },
+    { english: 'I\'d be happy to share some resources on that if it would be useful.', context: 'Offering to help', register: 'neutral' },
+    { english: 'It was a pleasure speaking with you — let\'s stay in touch.', context: 'Closing a networking conversation', register: 'formal' },
+    { english: 'I\'ll send you a LinkedIn request so we can keep the conversation going.', context: 'Following up after meeting', register: 'neutral' },
+    { english: 'Do you have a card, or shall I find you on LinkedIn?', context: 'Exchanging contact details', register: 'neutral' },
+  ],
+}
+
+const conflict_resolution_c1: PhrasebookCategory = {
+  id: 'conflict_resolution_c1',
+  level: 'C1',
+  situation: 'Conflict Resolution',
+  icon: '🕊️',
+  phrases: [
+    { english: 'I sense there may be some tension around this issue — shall we address it openly?', context: 'Naming a conflict and inviting dialogue', register: 'formal' },
+    { english: 'I understand this is a difficult situation for all parties involved.', context: 'Showing empathy before discussing solutions', register: 'formal' },
+    { english: 'I\'d like to hear your perspective before I share mine.', context: 'Demonstrating willingness to listen', register: 'neutral' },
+    { english: 'I think there may have been a misunderstanding — let me clarify my position.', context: 'Addressing a miscommunication', register: 'neutral' },
+    { english: 'Our goal should be to find a solution that works for everyone.', context: 'Refocusing on shared interests', register: 'neutral' },
+    { english: 'I\'m willing to reconsider my stance if you can walk me through your reasoning.', context: 'Showing openness to compromise', register: 'formal' },
+    { english: 'Could we agree to set this point aside for now and return to it later?', context: 'De-escalating a heated point', register: 'formal' },
+    { english: 'I want to be direct without being dismissive of your concerns.', context: 'Balancing honesty with respect', register: 'neutral' },
+    { english: 'What would a satisfactory outcome look like from your perspective?', context: 'Inviting the other party to define success', register: 'formal' },
+    { english: 'I think we\'re closer to agreement than it might appear.', context: 'Building bridges at a tense moment', register: 'neutral' },
+  ],
+}
+
 // ─── C2 Categories ────────────────────────────────────────────────────────────
 
 const rhetoric_c2: PhrasebookCategory = {
@@ -462,6 +500,46 @@ const nuanced_discourse_c2: PhrasebookCategory = {
   ],
 }
 
+const legal_contractual_c2: PhrasebookCategory = {
+  id: 'legal_contractual_c2',
+  level: 'C2',
+  situation: 'Legal & Contractual Language',
+  icon: '📜',
+  phrases: [
+    { english: 'The terms set out herein are binding upon both parties.', context: 'Formal contract phrasing', register: 'formal' },
+    { english: 'Notwithstanding the foregoing, …', context: 'Introducing a qualification to a prior statement', register: 'formal' },
+    { english: 'The party of the first part hereby agrees to…', context: 'Initiating a formal obligation', register: 'formal' },
+    { english: 'This agreement shall be governed by and construed in accordance with the laws of [jurisdiction].', context: 'Specifying governing law', register: 'formal' },
+    { english: 'Any dispute arising out of or in connection with this contract shall be referred to arbitration.', context: 'Dispute resolution clause', register: 'formal' },
+    { english: 'Time is of the essence with respect to delivery.', context: 'Stressing deadline importance', register: 'formal' },
+    { english: 'The licensor grants a non-exclusive, non-transferable licence to use…', context: 'Licensing language', register: 'formal' },
+    { english: 'Either party may terminate this agreement upon [n] days\' written notice.', context: 'Termination clause', register: 'formal' },
+    { english: 'This clause shall survive the termination of the agreement.', context: 'Survival clause', register: 'formal' },
+    { english: 'Without prejudice to any other rights or remedies available, …', context: 'Reserving additional rights', register: 'formal' },
+    { english: 'Force majeure events shall excuse performance obligations.', context: 'Addressing unforeseeable circumstances', register: 'formal' },
+  ],
+}
+
+const social_commentary_c2: PhrasebookCategory = {
+  id: 'social_commentary_c2',
+  level: 'C2',
+  situation: 'Social Commentary & Debate',
+  icon: '🗞️',
+  phrases: [
+    { english: 'The systemic nature of this problem demands a structural response, not a piecemeal one.', context: 'Arguing for root-cause solutions', register: 'formal' },
+    { english: 'We risk conflating two very different phenomena if we treat them as equivalent.', context: 'Warning against false equivalence', register: 'formal' },
+    { english: 'The dominant narrative obscures more than it reveals.', context: 'Challenging mainstream framing', register: 'formal' },
+    { english: 'There is a troubling tendency to mistake complexity for ambiguity.', context: 'Distinguishing nuance from vagueness', register: 'formal' },
+    { english: 'The discourse around this issue has been, at best, superficial.', context: 'Critiquing the quality of public debate', register: 'formal' },
+    { english: 'What we are witnessing is the logical consequence of decades of policy neglect.', context: 'Tracing cause and effect', register: 'formal' },
+    { english: 'Moral outrage, however justified, is not a substitute for analysis.', context: 'Calling for reason over emotion', register: 'formal' },
+    { english: 'The question is not whether change is needed, but who bears the cost of that change.', context: 'Reframing a debate around equity', register: 'formal' },
+    { english: 'History offers no shortage of cautionary tales on this front.', context: 'Invoking historical precedent', register: 'formal' },
+    { english: 'We should resist the temptation to reduce a multifaceted issue to a single cause.', context: 'Opposing oversimplification', register: 'formal' },
+    { english: 'The stakes could hardly be higher.', context: 'Emphasising urgency', register: 'formal' },
+  ],
+}
+
 // ─── Full phrasebook ──────────────────────────────────────────────────────────
 
 export const phrasebookCategories: PhrasebookCategory[] = [
@@ -489,9 +567,13 @@ export const phrasebookCategories: PhrasebookCategory[] = [
   // C1
   presentations_c1,
   complex_arguments_c1,
+  professional_networking_c1,
+  conflict_resolution_c1,
   // C2
   rhetoric_c2,
   nuanced_discourse_c2,
+  legal_contractual_c2,
+  social_commentary_c2,
 ]
 
 /** Return all categories for a given CEFR level */

--- a/frontend/src/data/en/vocabulary.ts
+++ b/frontend/src/data/en/vocabulary.ts
@@ -1523,6 +1523,27 @@ const critical_analysis_c2: VocabularySet = {
   ],
 }
 
+const advanced_verbs_thought_c2: VocabularySet = {
+  id: 'advanced_verbs_thought_c2',
+  level: 'C2',
+  topic: 'Advanced Verbs of Thought & Communication',
+  unit_ref: 'c2-unit-6',
+  words: [
+    { word: 'elucidate', pos: 'verb', definition: 'To make something clear; to explain in detail.', example: 'The professor elucidated the theorem with several examples.', ipa: '/ɪˈluːsɪdeɪt/', frequency_rank: 460 },
+    { word: 'extrapolate', pos: 'verb', definition: 'To extend a conclusion beyond the available data; to infer from known facts.', example: 'We cannot extrapolate global trends from a single study.', ipa: '/ɪkˈstræpəleɪt/', frequency_rank: 440 },
+    { word: 'surmise', pos: 'verb', definition: 'To suppose without sufficient evidence; to conjecture.', example: 'She surmised that the delay was intentional.', ipa: '/səˈmaɪz/', frequency_rank: 450 },
+    { word: 'promulgate', pos: 'verb', definition: 'To make a law or policy widely known; to disseminate officially.', example: 'The new regulations were promulgated by the ministry.', ipa: '/ˈprɒməlɡeɪt/', frequency_rank: 470 },
+    { word: 'expound', pos: 'verb', definition: 'To present and explain a theory or idea in detail.', example: 'The scientist expounded her findings at the conference.', ipa: '/ɪkˈspaʊnd/', frequency_rank: 450 },
+    { word: 'impute', pos: 'verb', definition: 'To attribute a quality or characteristic to someone; to assign blame.', example: 'The failure was imputed to a lack of oversight.', ipa: '/ɪmˈpjuːt/', frequency_rank: 460 },
+    { word: 'misconstrue', pos: 'verb', definition: 'To interpret something incorrectly.', example: 'His silence was misconstrued as agreement.', ipa: '/ˌmɪskənˈstruː/', frequency_rank: 450 },
+    { word: 'corroborate', pos: 'verb', definition: 'To confirm or give support to a statement, theory, or finding.', example: 'The witness corroborated the defendant\'s alibi.', ipa: '/kəˈrɒbəreɪt/', frequency_rank: 420 },
+    { word: 'articulate', pos: 'verb', definition: 'To express an idea clearly and coherently.', example: 'She articulated her concerns in a formal letter.', ipa: '/ɑːˈtɪkjʊleɪt/', frequency_rank: 300 },
+    { word: 'conjecture', pos: 'verb', definition: 'To form an opinion or theory without firm evidence.', example: 'Historians can only conjecture about his true motives.', ipa: '/kənˈdʒektʃər/', frequency_rank: 450 },
+    { word: 'expatiate', pos: 'verb', definition: 'To speak or write at length about a subject.', example: 'The essay expatiated on the consequences of colonialism.', ipa: '/ɪkˈspeɪʃieɪt/', frequency_rank: 490 },
+    { word: 'infer', pos: 'verb', definition: 'To deduce or conclude from evidence and reasoning.', example: 'From the data, we can infer a strong correlation.', ipa: '/ɪnˈfɜːr/', frequency_rank: 280 },
+  ],
+}
+
 // ─── Vocabulary index ─────────────────────────────────────────────────────────
 
 export const vocabularySets: VocabularySet[] = [
@@ -1601,6 +1622,7 @@ export const vocabularySets: VocabularySet[] = [
   idiomatic_expressions_c2,
   literary_devices_c2,
   critical_analysis_c2,
+  advanced_verbs_thought_c2,
 ]
 
 /** Look up a VocabularySet by id */

--- a/messages/de.json
+++ b/messages/de.json
@@ -122,7 +122,11 @@
     "conversationSaved": "Gesprächseinstellungen gespeichert.",
     "sectionAuthor": "Autor",
     "authorDescription": "Erstellt von Arturo Carretero Calvo",
-    "githubProfile": "GitHub-Profil"
+    "githubProfile": "GitHub-Profil",
+    "deleteAccount": "Konto löschen",
+    "deleteAccountTitle": "Konto löschen",
+    "deleteAccountMessage": "Diese Aktion löscht dein Konto und alle deine Daten dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "deleteAccountConfirm": "Konto löschen"
   },
   "dashboard": {
     "welcomeBack": "Willkommen zurück",
@@ -392,13 +396,15 @@
     "backToGrammar": "Grammatik",
     "explanation": "Erklärung",
     "backLink": "Zurück zur Grammatik",
-    "notFound": "Thema nicht gefunden."
+    "notFound": "Thema nicht gefunden.",
+    "topicsFound": "{count, plural, one {# Thema gefunden} other {# Themen gefunden}}"
   },
   "vocabulary": {
     "title": "Vokabular",
     "subtitle": "Vokabular",
     "all": "Alle",
     "searchPlaceholder": "Sammlungen suchen...",
+    "sets": "Sammlungen",
     "words": "Wörter",
     "addAll": "Alle {count} als Karteikarten hinzufügen",
     "adding": "Wird hinzugefügt...",
@@ -425,7 +431,9 @@
     "copy": "Kopieren",
     "noResults": "Keine Phrasen gefunden",
     "level": "Niveau",
-    "register": "Register"
+    "register": "Register",
+    "statsLine": "{situationCount} Situationen · {phraseCount} Phrasen · {range}",
+    "situationsShown": "{count, plural, one {# Situation angezeigt} other {# Situationen angezeigt}}"
   },
   "admin": {
     "title": "Verwaltung",

--- a/messages/en.json
+++ b/messages/en.json
@@ -122,7 +122,11 @@
     "conversationSaved": "Conversation settings saved.",
     "sectionAuthor": "Author",
     "authorDescription": "Built by Arturo Carretero Calvo",
-    "githubProfile": "GitHub profile"
+    "githubProfile": "GitHub profile",
+    "deleteAccount": "Delete Account",
+    "deleteAccountTitle": "Delete Account",
+    "deleteAccountMessage": "This will permanently delete your account and all your data. This action cannot be undone.",
+    "deleteAccountConfirm": "Delete Account"
   },
   "dashboard": {
     "welcomeBack": "Welcome back",
@@ -392,13 +396,15 @@
     "backToGrammar": "Grammar Reference",
     "explanation": "Explanation",
     "backLink": "Back to Grammar",
-    "notFound": "Topic not found."
+    "notFound": "Topic not found.",
+    "topicsFound": "{count, plural, one {# topic found} other {# topics found}}"
   },
   "vocabulary": {
     "title": "Vocabulary Hub",
     "subtitle": "Vocabulary",
     "all": "All",
     "searchPlaceholder": "Search sets…",
+    "sets": "sets",
     "words": "words",
     "addAll": "Add All {count} to Flashcards",
     "adding": "Adding...",
@@ -425,7 +431,9 @@
     "copy": "Copy",
     "noResults": "No phrases match your filters",
     "level": "Level",
-    "register": "Register"
+    "register": "Register",
+    "statsLine": "{situationCount} situations · {phraseCount} phrases · {range}",
+    "situationsShown": "{count, plural, one {# situation shown} other {# situations shown}}"
   },
   "admin": {
     "title": "Admin",

--- a/messages/es.json
+++ b/messages/es.json
@@ -122,7 +122,11 @@
     "conversationSaved": "Configuración de conversación guardada.",
     "sectionAuthor": "Autor",
     "authorDescription": "Creado por Arturo Carretero Calvo",
-    "githubProfile": "Perfil de GitHub"
+    "githubProfile": "Perfil de GitHub",
+    "deleteAccount": "Eliminar cuenta",
+    "deleteAccountTitle": "Eliminar cuenta",
+    "deleteAccountMessage": "Esta acción eliminará tu cuenta y todos tus datos de forma permanente. Esta acción no se puede deshacer.",
+    "deleteAccountConfirm": "Eliminar cuenta"
   },
   "dashboard": {
     "welcomeBack": "Bienvenido de vuelta",
@@ -392,13 +396,15 @@
     "backToGrammar": "Gramática",
     "explanation": "Explicación",
     "backLink": "Volver a gramática",
-    "notFound": "Tema no encontrado."
+    "notFound": "Tema no encontrado.",
+    "topicsFound": "{count, plural, one {# tema encontrado} other {# temas encontrados}}"
   },
   "vocabulary": {
     "title": "Vocabulario",
     "subtitle": "Vocabulario",
     "all": "Todos",
     "searchPlaceholder": "Buscar conjuntos…",
+    "sets": "conjuntos",
     "words": "palabras",
     "addAll": "Añadir las {count} a tarjetas",
     "adding": "Añadiendo…",
@@ -425,7 +431,9 @@
     "copy": "Copiar",
     "noResults": "Ninguna frase coincide con los filtros",
     "level": "Nivel",
-    "register": "Registro"
+    "register": "Registro",
+    "statsLine": "{situationCount} situaciones · {phraseCount} frases · {range}",
+    "situationsShown": "{count, plural, one {# situación mostrada} other {# situaciones mostradas}}"
   },
   "admin": {
     "title": "Administración",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -122,7 +122,11 @@
     "conversationSaved": "Paramètres de conversation enregistrés.",
     "sectionAuthor": "Auteur",
     "authorDescription": "Créé par Arturo Carretero Calvo",
-    "githubProfile": "Profil GitHub"
+    "githubProfile": "Profil GitHub",
+    "deleteAccount": "Supprimer le compte",
+    "deleteAccountTitle": "Supprimer le compte",
+    "deleteAccountMessage": "Cette action supprimera définitivement votre compte et toutes vos données. Cette action est irréversible.",
+    "deleteAccountConfirm": "Supprimer le compte"
   },
   "dashboard": {
     "welcomeBack": "Bon retour",
@@ -392,13 +396,15 @@
     "backToGrammar": "Grammaire",
     "explanation": "Explication",
     "backLink": "Retour à la grammaire",
-    "notFound": "Thème introuvable."
+    "notFound": "Thème introuvable.",
+    "topicsFound": "{count, plural, one {# thème trouvé} other {# thèmes trouvés}}"
   },
   "vocabulary": {
     "title": "Vocabulaire",
     "subtitle": "Vocabulaire",
     "all": "Tous",
     "searchPlaceholder": "Rechercher des ensembles...",
+    "sets": "ensembles",
     "words": "mots",
     "addAll": "Ajouter les {count} en fiches",
     "adding": "Ajout...",
@@ -425,7 +431,9 @@
     "copy": "Copier",
     "noResults": "Aucune phrase ne correspond aux filtres",
     "level": "Niveau",
-    "register": "Registre"
+    "register": "Registre",
+    "statsLine": "{situationCount} situations · {phraseCount} phrases · {range}",
+    "situationsShown": "{count, plural, one {# situation affichée} other {# situations affichées}}"
   },
   "admin": {
     "title": "Administration",

--- a/messages/it.json
+++ b/messages/it.json
@@ -122,7 +122,11 @@
     "conversationSaved": "Impostazioni conversazione salvate.",
     "sectionAuthor": "Autore",
     "authorDescription": "Creato da Arturo Carretero Calvo",
-    "githubProfile": "Profilo GitHub"
+    "githubProfile": "Profilo GitHub",
+    "deleteAccount": "Elimina account",
+    "deleteAccountTitle": "Elimina account",
+    "deleteAccountMessage": "Questa azione eliminerà definitivamente il tuo account e tutti i tuoi dati. Questa azione non può essere annullata.",
+    "deleteAccountConfirm": "Elimina account"
   },
   "dashboard": {
     "welcomeBack": "Bentornato",
@@ -392,13 +396,15 @@
     "backToGrammar": "Grammatica",
     "explanation": "Spiegazione",
     "backLink": "Torna alla grammatica",
-    "notFound": "Argomento non trovato."
+    "notFound": "Argomento non trovato.",
+    "topicsFound": "{count, plural, one {# argomento trovato} other {# argomenti trovati}}"
   },
   "vocabulary": {
     "title": "Vocabolario",
     "subtitle": "Vocabolario",
     "all": "Tutti",
     "searchPlaceholder": "Cerca set...",
+    "sets": "set",
     "words": "parole",
     "addAll": "Aggiungi tutti i {count} alle schede",
     "adding": "Aggiunta...",
@@ -425,7 +431,9 @@
     "copy": "Copia",
     "noResults": "Nessuna frase corrisponde ai filtri",
     "level": "Livello",
-    "register": "Registro"
+    "register": "Registro",
+    "statsLine": "{situationCount} situazioni · {phraseCount} frasi · {range}",
+    "situationsShown": "{count, plural, one {# situazione mostrata} other {# situazioni mostrate}}"
   },
   "admin": {
     "title": "Amministrazione",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -122,7 +122,11 @@
     "conversationSaved": "Configurações de conversa guardadas.",
     "sectionAuthor": "Autor",
     "authorDescription": "Criado por Arturo Carretero Calvo",
-    "githubProfile": "Perfil do GitHub"
+    "githubProfile": "Perfil do GitHub",
+    "deleteAccount": "Excluir conta",
+    "deleteAccountTitle": "Excluir conta",
+    "deleteAccountMessage": "Esta ação excluirá permanentemente sua conta e todos os seus dados. Esta ação não pode ser desfeita.",
+    "deleteAccountConfirm": "Excluir conta"
   },
   "dashboard": {
     "welcomeBack": "Bem-vindo de volta",
@@ -354,13 +358,15 @@
     "backToGrammar": "Gramática",
     "explanation": "Explicação",
     "backLink": "Voltar à gramática",
-    "notFound": "Tópico não encontrado."
+    "notFound": "Tópico não encontrado.",
+    "topicsFound": "{count, plural, one {# tópico encontrado} other {# tópicos encontrados}}"
   },
   "vocabulary": {
     "title": "Vocabulário",
     "subtitle": "Vocabulário",
     "all": "Todos",
     "searchPlaceholder": "Pesquisar conjuntos...",
+    "sets": "conjuntos",
     "words": "palavras",
     "addAll": "Adicionar {count} aos cartões",
     "adding": "Adicionando...",
@@ -387,7 +393,9 @@
     "copy": "Copiar",
     "noResults": "Nenhuma frase corresponde aos filtros",
     "level": "Nível",
-    "register": "Registo"
+    "register": "Registo",
+    "statsLine": "{situationCount} situações · {phraseCount} frases · {range}",
+    "situationsShown": "{count, plural, one {# situação exibida} other {# situações exibidas}}"
   },
   "admin": {
     "title": "Administração",

--- a/specs/architecture.instructions.md
+++ b/specs/architecture.instructions.md
@@ -11,94 +11,41 @@ applyTo: "backend/**, frontend/**"
 freelingo/
 ├── backend/                     # Python 3.12 FastAPI
 │   ├── app/
-│   │   ├── main.py              # FastAPI app, lifespan, middleware, router mounting
-│   │   ├── core/
-│   │   │   ├── config.py        # Settings via pydantic-settings (.env)
-│   │   │   ├── database.py      # Async SQLAlchemy engine, session factory
-│   │   │   ├── security.py      # JWT encode/decode (HS256), bcrypt password hashing
-│   │   │   ├── deps.py          # Dependency injection: get_current_user, require_admin
-│   │   │   └── limiter.py       # slowapi rate limiter (200/min default)
-│   │   ├── models/              # 9 SQLAlchemy 2.0 async ORM models
-│   │   │   ├── user.py          # User
-│   │   │   ├── study_plan.py    # StudyPlan
-│   │   │   ├── lesson.py        # Lesson + Exercise
-│   │   │   ├── flashcard.py     # Flashcard (SM-2 fields)
-│   │   │   ├── progress.py      # Progress (daily XP/streak/skills)
-│   │   │   ├── conversation.py  # Conversation
-│   │   │   ├── chat_history.py  # ChatHistory
-│   │   │   └── competency.py    # UserCompetency (unit-level)
-│   │   ├── schemas/             # Pydantic v2 request/response models
+│   │   ├── core/                # Config, DB engine, security, deps, rate limiter
+│   │   ├── models/              # SQLAlchemy 2.0 ORM models (9 models)
+│   │   ├── schemas/             # Pydantic v2 request/response schemas
 │   │   ├── routers/             # 11 routers (10 REST + 1 WebSocket)
-│   │   │   ├── auth.py          # /api/auth/*
-│   │   │   ├── admin.py         # /api/admin/* (admin-only)
-│   │   │   ├── assessment.py    # /api/assessment/*
-│   │   │   ├── study_plan.py    # /api/study-plan/*
-│   │   │   ├── lessons.py       # /api/lessons/*
-│   │   │   ├── flashcards.py    # /api/flashcards/*
-│   │   │   ├── chat.py          # /api/chat/* (SSE streaming)
-│   │   │   ├── progress.py      # /api/progress/*
-│   │   │   ├── tts.py           # /api/tts (proxied to Kokoro)
-│   │   │   ├── stt.py           # /api/stt (proxied to Whisper)
-│   │   │   └── conversation.py  # /ws/conversation (WebSocket)
-│   │   ├── services/            # 9 service modules
-│   │   │   ├── llm_adapter.py           # Multi-provider LLM client
-│   │   │   ├── assessment.py            # Deterministic CEFR evaluation + LLM helpers
-│   │   │   ├── study_plan_generator.py  # Curriculum-driven plan (no LLM)
-│   │   │   ├── lesson_generator.py      # LLM lesson content generation
-│   │   │   ├── flashcard_sm2.py         # SM-2 algorithm + LLM flashcard gen
-│   │   │   ├── progress_service.py      # XP, streaks, skills, unit competency
-│   │   │   ├── tts_service.py           # Kokoro HTTP client
-│   │   │   ├── stt_service.py           # Whisper HTTP client
-│   │   │   └── conversation_pipeline.py # WebSocket STT→LLM→TTS pipeline
+│   │   ├── services/            # Business logic + external service clients (10 modules)
 │   │   └── data/
-│   │       └── curriculum.py    # CEFR curriculum A1-C2 (24 units), intensity config
-│   ├── alembic/                 # Async DB migrations (6 migrations)
-│   ├── tests/                   # 10 test files (pytest + pytest-asyncio)
-│   ├── pyproject.toml           # ruff, black, pytest config
-│   └── requirements.txt         # 20+ dependencies
+│   │       └── en/              # Static curriculum and content data
+│   ├── alembic/
+│   │   └── versions/            # DB migrations (7)
+│   └── tests/                   # pytest suite (10 test files)
 │
 ├── frontend/                    # Next.js 16 App Router
 │   ├── src/
-│   │   ├── app/                 # Routes (page.tsx files)
-│   │   │   ├── (auth)/          # Public routes (login, register) — no sidebar
+│   │   ├── app/
+│   │   │   ├── (auth)/          # Public routes (login, register, onboarding) — no sidebar
 │   │   │   ├── (app)/           # Authenticated routes — sidebar layout
-│   │   │   │   ├── dashboard/      # Main dashboard
-│   │   │   │   ├── assessment/     # 3-step onboarding (beginner gate → quiz → plan)
-│   │   │   │   ├── assessment/level-test/  # End-of-level test
-│   │   │   │   ├── plan/           # Curriculum roadmap
-│   │   │   │   ├── lesson/[id]/    # Lesson content + exercises
-│   │   │   │   ├── flashcards/     # SM-2 review, generate, speaking mode
-│   │   │   │   ├── chat/           # AI tutor (SSE streaming)
-│   │   │   │   ├── conversation/   # Voice conversation (WebSocket + VAD)
-│   │   │   │   ├── grammar/        # Grammar reference index
-│   │   │   │   ├── grammar/[slug]/ # Grammar topic detail
-│   │   │   │   ├── vocabulary/     # Vocabulary hub index
-│   │   │   │   ├── vocabulary/[setId]/  # Vocabulary set detail
-│   │   │   │   ├── phrasebook/     # Phrasebook with filters
-│   │   │   │   ├── progress/       # Skills tracker
-│   │   │   │   ├── settings/       # User profile + admin
-│   │   │   │   ├── faq/            # FAQ page
-│   │   │   │   └── admin/users/    # Admin user management
-│   │   │   └── api/            # Next.js Route Handlers (SSE/binary proxies)
-│   │   ├── components/         # React components (shadcn/ui + custom)
-│   │   ├── data/               # Static data (5 files: curriculum, grammar, vocab, phrasebook, assessment-bank)
-│   │   ├── store/              # Zustand stores (auth, theme, progress, loading)
-│   │   ├── lib/                # Utilities (api fetch, WS builder, audio queue)
-│   │   ├── i18n/               # next-intl locale resolver
-│   │   └── middleware.ts       # Auth guard + locale detection
-│   ├── public/                 # Static assets (flags, VAD WASM models)
-│   └── scripts/
-│       └── copy-vad-models.js  # Postinstall: VAD models → public/
+│   │   │   └── api/             # Next.js Route Handlers (SSE / binary proxies)
+│   │   ├── components/          # React components (shadcn/ui + custom)
+│   │   ├── data/                # Static data (curriculum, grammar, vocab, phrasebook, assessment-bank)
+│   │   ├── store/               # Zustand stores (auth, theme, progress, loading)
+│   │   ├── lib/                 # Utilities (apiFetch, WS builder, audio queue, target-languages)
+│   │   ├── i18n/                # next-intl locale resolver
+│   │   └── middleware.ts        # Auth guard + locale detection
+│   ├── public/                  # Static assets (flags, VAD WASM models)
+│   └── scripts/                 # Postinstall helpers (copy-vad-models.js)
 │
-├── messages/                   # i18n message bundles (en, es, fr, pt, de, it)
+├── messages/                    # i18n bundles (en, es, fr, pt, de, it)
+├── specs/                       # Architecture and phase specification files
+├── docs/                        # Documentation site
+├── assets/                      # Logo and branding
+├── .github/                     # CI/CD workflows (GitHub Actions)
 ├── docker-compose.yml
 ├── .env.example
-├── docker/                     # Custom Dockerfiles (optional overrides)
-├── docs/                       # Documentation
-├── assets/                     # Logo, branding
-├── .github/                    # CI/CD workflows (GitHub Actions)
-├── AGENTS.md                   # Agent instructions for AI assistants
-├── CHANGELOG.md                # Version history
+├── AGENTS.md                    # Agent instructions for AI assistants
+├── CHANGELOG.md
 └── README.md
 ```
 
@@ -119,7 +66,7 @@ Registration, authentication, and user preferences.
 | hashed_password | string | bcrypt hash |
 | role | string | `"admin"` or `"user"` |
 | native_language | string | e.g. `"es"`, `"fr"` — used for flashcard translations and tutor feedback |
-| english_variant | string | `"american"` (default) or `"british"` — controls grammar/spelling |
+| target_language | string | BCP-47 tag, e.g. `"en-US"` (default) or `"en-GB"` — the language the user is learning |
 | is_active | boolean | False = account disabled by admin |
 | conversation_max_duration | integer | Max voice session duration in seconds (default 1800) |
 | conversation_inactivity_timeout | integer | Seconds of silence before disconnect (default 180) |
@@ -129,7 +76,8 @@ Registration, authentication, and user preferences.
 **Registration rules:**
 - First registered user becomes admin automatically when `FIRST_USER_IS_ADMIN=true` (default).
 - `ALLOW_REGISTRATION=false` blocks public signups; admin creates users or generates single-use invite links (48h expiry in Redis).
-- Target language is always English. User's native language is used only for flashcard translations and tutor feedback.
+- `POST /register` returns an `access_token` + sets the refresh token cookie so the frontend can redirect directly to `/onboarding` without an intermediate login.
+- On `/onboarding` the user chooses their `target_language`; the choice is saved via `PATCH /me` before accessing the app.
 
 ### StudyPlan (`study_plans`)
 
@@ -149,6 +97,7 @@ One active plan per user. Generated after CEFR assessment.
 | completion_test_taken | boolean | Whether end-of-level test was completed |
 | completion_test_score | float (nullable) | 0.0 – 1.0 |
 | completion_test_recommendation | string (nullable) | `"advance"`, `"extend"`, or `"repeat"` |
+| target_language | string | BCP-47 tag copied from user at plan creation (e.g. `"en-US"`) |
 | created_at | datetime | Auto-set |
 
 **Intensity / duration mapping:**
@@ -281,7 +230,7 @@ Per-unit competency tracking (Phase 1+).
 | POST | `/refresh` | 20/min | Rotates refresh token, returns new access_token |
 | POST | `/logout` | None | Deletes refresh token from Redis, clears cookie |
 | GET | `/me` | None | Returns authenticated user profile |
-| PATCH | `/me` | None | Updates display_name, email, password, english_variant, conversation settings |
+| PATCH | `/me` | None | Updates display_name, email, password, target_language, conversation settings |
 
 ### Admin — `/api/admin` (requires `role="admin"`)
 
@@ -418,7 +367,7 @@ Fully deterministic — no LLM. Uses static curriculum data from `curriculum.py`
 
 LLM-powered lesson content generation with strict constraints:
 - Grammar constrained to a validated set of 24 grammar slugs
-- CEFR level and English variant (american/british) adherence
+- CEFR level and target language adherence (`en-US` / `en-GB`; BCP-47 tag converted to english variant via `language_helpers.get_english_variant`)
 - Generates 3-5 exercises per lesson (multiple_choice, fill_blank, free_write)
 - Separately evaluates free_write answers and pronunciation (scored 0.0–1.0 with feedback)
 
@@ -426,7 +375,13 @@ LLM-powered lesson content generation with strict constraints:
 
 Full SM-2 spaced repetition algorithm:
 - `sm2_update(card, quality)`: modifies ease_factor, interval, repetitions, and next_review based on 0–5 quality rating
-- LLM-powered `generate_flashcards`: creates flashcards with native-language translations
+- LLM-powered `generate_flashcards`: creates flashcards with native-language translations; `native_language` is always sourced from the authenticated user's profile (not from the request body)
+
+### Language Helpers (`language_helpers.py`)
+
+Shared BCP-47 conversion utilities used across the service layer:
+- `get_english_variant(target_language)` — converts `"en-US"` → `"american"`, `"en-GB"` → `"british"` for LLM prompts
+- `get_iso639(target_language)` — strips region subtag: `"en-US"` → `"en"` for Whisper
 
 ### Progress Service (`progress_service.py`)
 
@@ -441,7 +396,7 @@ HTTP client to Kokoro-FastAPI: `POST /v1/audio/speech` with text, voice, and for
 
 ### STT Service (`stt_service.py`)
 
-HTTP client to Whisper ASR: `POST /asr?output=json&language=en&task=transcribe` with multipart audio upload. Returns transcribed text.
+HTTP client to Whisper ASR: `POST /asr?output=json&language=<lang>&task=transcribe` with multipart audio upload. Returns transcribed text. The `language` parameter is derived dynamically from `target_language` via `language_helpers.get_iso639` (e.g. `"en-US"` → `"en"`).
 
 **Note**: The STT endpoint is `/asr` (not OpenAI-compatible `/v1/audio/transcriptions`). This is the actual API of the `onerahmet/openai-whisper-asr-webservice` Docker image.
 

--- a/specs/phase-4-target-language.instructions.md
+++ b/specs/phase-4-target-language.instructions.md
@@ -494,18 +494,18 @@ Returning users (second login) and admin-created users are unaffected — their 
 
 ## Phase 4 completion criteria
 
-- [ ] Migration `0007_target_language` runs without error on a database with pre-existing rows — `english_variant` values are correctly back-filled to BCP-47 codes
-- [ ] `POST /api/auth/register` returns `access_token` in the response body and sets the refresh_token httpOnly cookie
-- [ ] Registering with `target_language="en-GB"` stores `"en-GB"` in the database (not the old `"british"`)
-- [ ] Registering with an unsupported `target_language` value returns HTTP 422
-- [ ] After registration, the frontend is automatically authenticated (access_token stored) and redirected to `/onboarding`
-- [ ] `/onboarding` shows the `TargetLanguageSelector` with both `en-US` and `en-GB` options
-- [ ] Selecting a language and clicking "Start learning" calls `PATCH /api/auth/me` and redirects to `/dashboard`
-- [ ] Navigating to `/onboarding` directly without a valid access_token redirects to `/register`
-- [ ] `/settings` no longer shows the English variant selector
-- [ ] LLM-generated lessons and flashcards use the correct English variant derived from `target_language`
-- [ ] Voice conversation pipeline builds the system prompt with the correct `native_language` and `english_variant` (previously missing)
-- [ ] STT transcription uses the language code derived from `target_language` (`en` for both English variants)
-- [ ] `FlashcardGenerateRequest` no longer accepts a `native_language` field — translation language is always sourced from the user profile
-- [ ] All backend tests pass with `target_language` replacing `english_variant`
-- [ ] No regressions in Phases 1, 2, and 3
+- [x] Migration `0007_target_language` runs without error on a database with pre-existing rows — `english_variant` values are correctly back-filled to BCP-47 codes
+- [x] `POST /api/auth/register` returns `access_token` in the response body and sets the refresh_token httpOnly cookie
+- [x] Registering with `target_language="en-GB"` stores `"en-GB"` in the database (not the old `"british"`)
+- [x] Registering with an unsupported `target_language` value returns HTTP 422
+- [x] After registration, the frontend is automatically authenticated (access_token stored) and redirected to `/onboarding`
+- [x] `/onboarding` shows the `TargetLanguageSelector` with both `en-US` and `en-GB` options
+- [x] Selecting a language and clicking "Start learning" calls `PATCH /api/auth/me` and redirects to `/dashboard`
+- [x] Navigating to `/onboarding` directly without a valid access_token redirects to `/register`
+- [x] `/settings` no longer shows the English variant selector
+- [x] LLM-generated lessons and flashcards use the correct English variant derived from `target_language`
+- [x] Voice conversation pipeline builds the system prompt with the correct `native_language` and `english_variant` (previously missing)
+- [x] STT transcription uses the language code derived from `target_language` (`en` for both English variants)
+- [x] `FlashcardGenerateRequest` no longer accepts a `native_language` field — translation language is always sourced from the user profile
+- [x] All backend tests pass with `target_language` replacing `english_variant`
+- [x] No regressions in Phases 1, 2, and 3

--- a/specs/roadmap.instructions.md
+++ b/specs/roadmap.instructions.md
@@ -131,7 +131,7 @@ This document records what was built and the completion criteria met.
 
 ## Phase 4 — Multi-Language Support
 
-🔄 Status: In progress
+✅ Status: Complete (v1.3.0)
 
 > Expands the platform from English-only to a multi-target-language architecture.
 > Initial launch supports American English (`en-US`) and British English (`en-GB`),
@@ -157,4 +157,4 @@ This document records what was built and the completion criteria met.
 - [x] `TargetLanguageSelector` renders flags and correct translated labels
 - [x] All 6 locales contain `targetLanguages` and `onboarding` namespaces
 - [x] `tsc --noEmit` and `python3 -m compileall` pass clean
-- [ ] No regressions in Phases 1–3
+- [x] No regressions in Phases 1–3

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.2.6**
+**1.3.0**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request implements Phase 4 of the project, introducing target language selection (with BCP-47 codes) throughout the stack, a new onboarding flow, and auto-login on registration. It also adds user account deletion, improves i18n coverage, and updates several UI elements for clarity and completeness. The release is versioned as 1.3.0.

**Phase 4: Target Language Selection and Onboarding**

- The `english_variant` field is replaced by a generic `target_language` (BCP-47 code) across the backend and frontend. Alembic migration `0007_target_language.py` adds the new column, backfills data, and removes the old field. All relevant models, APIs, and validators are updated.
- A new onboarding page (`/onboarding`) is introduced, where users choose their English variant after registration. The `TargetLanguageSelector` component provides this selection UI, and supported languages are centralized in both backend and frontend.
- The registration flow now auto-logs in users, issuing tokens and redirecting to onboarding.
- All services and prompts now consume `target_language` instead of `english_variant`, and i18n keys are updated accordingly.
- The English variant selector is removed from the settings page; the choice is now made only during onboarding.

**User Account Deletion**

- Adds a new `DELETE /api/auth/me` endpoint on the backend for self-service account deletion, with a frontend UI (except for admin users). Confirmation dialog and error handling are included. [[1]](diffhunk://#diff-b05ab53047dc54d983428eb226c0072641769fe81e60bf6e22f581239c95ce81R246-R263) [[2]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0R38-R40) [[3]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0R106-R116) [[4]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0R332-R351)

**i18n and UI Improvements**

- Dashboard, grammar, phrasebook, and vocabulary pages now consistently use i18n for stats and labels, including dynamic counts and lesson type names. [[1]](diffhunk://#diff-63e171028f522f8d46ebc6a6fddcc5b9741c0646c098b4a35fa4682729490f2bR23) [[2]](diffhunk://#diff-63e171028f522f8d46ebc6a6fddcc5b9741c0646c098b4a35fa4682729490f2bL102-R103) [[3]](diffhunk://#diff-63e171028f522f8d46ebc6a6fddcc5b9741c0646c098b4a35fa4682729490f2bL129-R130) [[4]](diffhunk://#diff-dce365390c3e203bc551e1a987a8864171a8c9f5f78454f89fe035cbfa77bb1fL135-R135) [[5]](diffhunk://#diff-b46177d6f652ddef5d091660e9b2b5d611a3e3abc15e8e1508ce11c9c2fa9248L132-R136) [[6]](diffhunk://#diff-b46177d6f652ddef5d091660e9b2b5d611a3e3abc15e8e1508ce11c9c2fa9248L178-R182) [frontend/src/app/(app)/vocabulary/[setId]/page.tsxL100-R100](diffhunk://#diff-87964c5f7481c14b0300070a59a09ff668fe5a1f4dd475c4837acfe000f50b66L100-R100), [[7]](diffhunk://#diff-98198ff81754994309fd74b65c0161c32bea0e90654fc106e25bdce78587020bL73-R73)
- Phrasebook and grammar pages now display the full CEFR range (A1–C2). [[1]](diffhunk://#diff-b46177d6f652ddef5d091660e9b2b5d611a3e3abc15e8e1508ce11c9c2fa9248L10-R10) [[2]](diffhunk://#diff-b46177d6f652ddef5d091660e9b2b5d611a3e3abc15e8e1508ce11c9c2fa9248L132-R136)

**Documentation and Versioning**

- Updates `CHANGELOG.md` for 1.3.0, reflecting all major changes.
- Updates README to reflect completed multi-language support, onboarding flow, and target language selection. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R76) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L138-R138) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126)
- Updates version strings in the UI to v1.3.0. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L209-R209) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L315-R315)

**Error Handling**

- Improves error message display on registration to handle both string and array error responses from the backend.

**Other Minor Changes**

- Minor UI tweaks (e.g., button padding in `TargetLanguageSelector`).
- Removes the obsolete `docker/` folder from the project structure in the README.