### PR TITLE
feature: deploy to main

### DIFF
--- a/frontend/src/app/(app)/plan/page.tsx
+++ b/frontend/src/app/(app)/plan/page.tsx
@@ -31,12 +31,14 @@ interface StudyPlan {
   completion_test_taken: boolean
   completion_test_score: number | null
   completion_test_recommendation: string | null
-  plan: {
-    weeks: {
-      week_number: number
+  generated_plan: {
+    weekly_plan: {
+      week: number
       days: {
-        day_number: number
-        lessons: Lesson[]
+        day: number
+        title: string
+        lesson_type: string
+        unit_id: string
       }[]
     }[]
   }
@@ -50,11 +52,17 @@ interface CompetencyMap {
 
 function flattenLessons(plan: StudyPlan): Lesson[] {
   const result: Lesson[] = []
-  for (const week of plan.plan.weeks) {
+  for (const week of plan.generated_plan.weekly_plan) {
     for (const day of week.days) {
-      for (const lesson of day.lessons) {
-        result.push({ ...lesson, week: week.week_number, day: day.day_number })
-      }
+      result.push({
+        id: null,
+        title: day.title,
+        lesson_type: day.lesson_type,
+        week: week.week,
+        day: day.day,
+        unit_id: day.unit_id,
+        completed: false,
+      })
     }
   }
   return result
@@ -203,7 +211,7 @@ export default function PlanPage() {
               {t('noUnitsForLevel', { level })}
             </p>
             <p className="font-mono text-fl-label text-fl-muted-4">
-              Content for this level is being prepared. Check back soon.
+              {t('noUnitsDesc')}
             </p>
           </div>
         )}
@@ -243,7 +251,7 @@ export default function PlanPage() {
         {/* Level test pseudo-unit */}
         {units.length > 0 && (
           <UnitCard
-            title={`Level ${level} Completion Test`}
+            title={t('completionTestTitle', { level })}
             index={units.length}
             lessonCount={1}
             grammarCount={0}
@@ -272,10 +280,10 @@ export default function PlanPage() {
       {plan.completion_test_taken && (
         <div className="border border-fl-border bg-fl-surface px-6 py-4 space-y-2">
           <p className="font-mono text-fl-hint tracking-widest text-fl-muted-3 uppercase">
-            Level Test Result
+            {t('levelTestResult')}
           </p>
           <p className="font-mono text-fl-body text-fl-fg">
-            Score:{' '}
+            {t('testScore')}{' '}
             <span className="font-bold">
               {plan.completion_test_score != null
                 ? `${Math.round(plan.completion_test_score * 100)}%`

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -42,7 +42,7 @@ function LoginForm() {
         })
         if (!res.ok) {
           const data = await res.json()
-          throw new Error(data.detail || 'Invalid credentials')
+          throw new Error(data.detail || t('error'))
         }
         const { access_token } = await res.json()
         setTokens(access_token)

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -57,7 +57,13 @@ function RegisterForm() {
           if (typeof data.detail === 'string') {
             msg = data.detail
           } else if (Array.isArray(data.detail) && data.detail.length > 0) {
-            msg = (data.detail[0] as { msg?: string }).msg ?? t('error')
+            const first = data.detail[0] as { type?: string; loc?: string[]; msg?: string }
+            const loc = (first.loc ?? []).join('.')
+            if (loc.includes('email') || first.msg?.toLowerCase().includes('email')) {
+              msg = t('invalidEmail')
+            } else {
+              msg = t('error')
+            }
           } else {
             msg = t('error')
           }

--- a/frontend/src/components/ui/confirm-dialog.tsx
+++ b/frontend/src/components/ui/confirm-dialog.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { useEffect } from 'react'
+import { useTranslations } from 'next-intl'
 
 interface ConfirmDialogProps {
   open: boolean
   title: string
   message: string
   confirmLabel?: string
+  cancelLabel?: string
   danger?: boolean
   onConfirm: () => void
   onCancel: () => void
@@ -17,10 +19,12 @@ export function ConfirmDialog({
   title,
   message,
   confirmLabel = 'Confirm',
+  cancelLabel,
   danger = false,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  const tCommon = useTranslations('common')
   // Close on Escape
   useEffect(() => {
     if (!open) return
@@ -60,13 +64,13 @@ export function ConfirmDialog({
             onClick={onCancel}
             className="flex-1 border border-fl-border py-3 font-mono text-fl-label font-bold tracking-widest uppercase text-fl-muted-2 hover:border-fl-border-2 hover:text-fl-fg transition-colors"
           >
-            — Cancel
+            — {cancelLabel ?? tCommon('cancel')}
           </button>
           <button
             onClick={onConfirm}
             className={`flex-1 py-3 font-mono text-fl-label font-bold tracking-widest uppercase transition-colors ${danger
-                ? 'bg-fl-error text-fl-fg-bright hover:bg-fl-error-hover'
-                : 'bg-fl-fg text-fl-bg hover:bg-fl-fg-bright'
+              ? 'bg-fl-error text-fl-fg-bright hover:bg-fl-error-hover'
+              : 'bg-fl-fg text-fl-bg hover:bg-fl-fg-bright'
               }`}
           >
             — {confirmLabel}

--- a/messages/de.json
+++ b/messages/de.json
@@ -80,7 +80,8 @@
       "confirmPassword": "Passwort bestätigen",
       "displayNamePlaceholder": "Gleich wie Benutzername wenn leer",
       "inviteActive": "Einladung aktiv",
-      "creatingAccount": "Wird erstellt..."
+      "creatingAccount": "Wird erstellt...",
+      "invalidEmail": "Bitte geben Sie eine gültige E-Mail-Adresse ein"
     }
   },
   "settings": {
@@ -282,7 +283,11 @@
     "nLessons": "{count} Lektionen",
     "nGrammar": "{count} Grammatik",
     "levelTestLabel": "Stufentest",
-    "unitAriaLabel": "Einheit {index}: {title}"
+    "unitAriaLabel": "Einheit {index}: {title}",
+    "noUnitsDesc": "Die Inhalte für diese Stufe werden gerade vorbereitet. Schau bald wieder vorbei.",
+    "completionTestTitle": "Stufenabschlusstest {level}",
+    "levelTestResult": "Stufentestergebnis",
+    "testScore": "Punktzahl:"
   },
   "lesson": {
     "loading": "Lektion wird geladen...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -80,7 +80,8 @@
       "confirmPassword": "Confirm Password",
       "displayNamePlaceholder": "Same as username if empty",
       "inviteActive": "Invite active",
-      "creatingAccount": "Creating..."
+      "creatingAccount": "Creating...",
+      "invalidEmail": "Please enter a valid email address"
     }
   },
   "settings": {
@@ -282,7 +283,11 @@
     "nLessons": "{count} lessons",
     "nGrammar": "{count} grammar",
     "levelTestLabel": "Level Test",
-    "unitAriaLabel": "Unit {index}: {title}"
+    "unitAriaLabel": "Unit {index}: {title}",
+    "noUnitsDesc": "Content for this level is being prepared. Check back soon.",
+    "completionTestTitle": "Level {level} Completion Test",
+    "levelTestResult": "Level Test Result",
+    "testScore": "Score:"
   },
   "lesson": {
     "loading": "Loading lesson...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -80,7 +80,8 @@
       "confirmPassword": "Confirmar contraseña",
       "displayNamePlaceholder": "Igual que el nombre de usuario si está vacío",
       "inviteActive": "Invitación activa",
-      "creatingAccount": "Creando..."
+      "creatingAccount": "Creando...",
+      "invalidEmail": "Por favor, introduce una dirección de correo válida"
     }
   },
   "settings": {
@@ -282,7 +283,11 @@
     "nLessons": "{count} lecciones",
     "nGrammar": "{count} gramática",
     "levelTestLabel": "Test de nivel",
-    "unitAriaLabel": "Unidad {index}: {title}"
+    "unitAriaLabel": "Unidad {index}: {title}",
+    "noUnitsDesc": "El contenido para este nivel está en preparación. Vuelve pronto.",
+    "completionTestTitle": "Test de finalización del nivel {level}",
+    "levelTestResult": "Resultado del test de nivel",
+    "testScore": "Puntuación:"
   },
   "lesson": {
     "loading": "Cargando lección…",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -80,7 +80,8 @@
       "confirmPassword": "Confirmer le mot de passe",
       "displayNamePlaceholder": "Même que le nom d'utilisateur si vide",
       "inviteActive": "Invitation active",
-      "creatingAccount": "Création en cours..."
+      "creatingAccount": "Création en cours...",
+      "invalidEmail": "Veuillez entrer une adresse e-mail valide"
     }
   },
   "settings": {
@@ -282,7 +283,11 @@
     "nLessons": "{count} leçons",
     "nGrammar": "{count} grammaire",
     "levelTestLabel": "Test de niveau",
-    "unitAriaLabel": "Unité {index} : {title}"
+    "unitAriaLabel": "Unité {index} : {title}",
+    "noUnitsDesc": "Le contenu pour ce niveau est en cours de préparation. Revenez bientôt.",
+    "completionTestTitle": "Test de fin de niveau {level}",
+    "levelTestResult": "Résultat du test de niveau",
+    "testScore": "Score :"
   },
   "lesson": {
     "loading": "Chargement de la leçon...",

--- a/messages/it.json
+++ b/messages/it.json
@@ -80,7 +80,8 @@
       "confirmPassword": "Conferma password",
       "displayNamePlaceholder": "Uguale al nome utente se vuoto",
       "inviteActive": "Invito attivo",
-      "creatingAccount": "Creazione in corso..."
+      "creatingAccount": "Creazione in corso...",
+      "invalidEmail": "Inserisci un indirizzo e-mail valido"
     }
   },
   "settings": {
@@ -282,7 +283,11 @@
     "nLessons": "{count} lezioni",
     "nGrammar": "{count} grammatica",
     "levelTestLabel": "Test di livello",
-    "unitAriaLabel": "Unità {index}: {title}"
+    "unitAriaLabel": "Unità {index}: {title}",
+    "noUnitsDesc": "Il contenuto per questo livello è in preparazione. Torna presto.",
+    "completionTestTitle": "Test di completamento livello {level}",
+    "levelTestResult": "Risultato del test di livello",
+    "testScore": "Punteggio:"
   },
   "lesson": {
     "loading": "Caricamento lezione...",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -80,7 +80,8 @@
       "confirmPassword": "Confirmar senha",
       "displayNamePlaceholder": "Mesmo que o nome de usuário se vazio",
       "inviteActive": "Convite ativo",
-      "creatingAccount": "Criando..."
+      "creatingAccount": "Criando...",
+      "invalidEmail": "Por favor, insira um endereço de e-mail válido"
     }
   },
   "settings": {
@@ -244,7 +245,11 @@
     "nLessons": "{count} aulas",
     "nGrammar": "{count} gramática",
     "levelTestLabel": "Teste de nível",
-    "unitAriaLabel": "Unidade {index}: {title}"
+    "unitAriaLabel": "Unidade {index}: {title}",
+    "noUnitsDesc": "O conteúdo para este nível está sendo preparado. Volte em breve.",
+    "completionTestTitle": "Teste de conclusão do nível {level}",
+    "levelTestResult": "Resultado do teste de nível",
+    "testScore": "Pontuação:"
   },
   "lesson": {
     "loading": "Carregando aula...",


### PR DESCRIPTION
This pull request introduces several improvements to the study plan page, authentication forms, and confirmation dialog component, with a strong focus on enhanced internationalization and error messaging. It also updates the structure of the study plan data and adds new translation keys and values across all supported languages.

**Study plan and UI improvements:**

* Refactored the `StudyPlan` interface and related logic in `plan/page.tsx` to use a new `generated_plan` structure, updating how weekly and daily plans are represented and flattened. This includes changing field names and removing the nested `lessons` array in favor of day-level attributes. [[1]](diffhunk://#diff-9b1e07081bbaf9ffdef0b5492f3b1076e248407c392d5ebb4cee19049fc7609bL34-R41) [[2]](diffhunk://#diff-9b1e07081bbaf9ffdef0b5492f3b1076e248407c392d5ebb4cee19049fc7609bL53-R65)
* Updated the study plan UI to use new translation keys for messages and titles, such as `noUnitsDesc`, `completionTestTitle`, `levelTestResult`, and `testScore`, ensuring all user-facing strings are translatable. [[1]](diffhunk://#diff-9b1e07081bbaf9ffdef0b5492f3b1076e248407c392d5ebb4cee19049fc7609bL206-R214) [[2]](diffhunk://#diff-9b1e07081bbaf9ffdef0b5492f3b1076e248407c392d5ebb4cee19049fc7609bL246-R254) [[3]](diffhunk://#diff-9b1e07081bbaf9ffdef0b5492f3b1076e248407c392d5ebb4cee19049fc7609bL275-R286)

**Authentication and error handling:**

* Improved error handling in the registration and login forms to provide more specific, localized error messages, including a new `invalidEmail` message when appropriate. [[1]](diffhunk://#diff-3c4ca477a77d81e567b05507a1b6e425cc4a8eb29e2a1a5914a0d6f3d5ee92f9L45-R45) [[2]](diffhunk://#diff-8635d23b595c2977887ee24801c4422a88d43f85fd138765e4dcb5ec1bbaac92L60-R66)

**Component enhancements:**

* Enhanced the `ConfirmDialog` component to accept an optional `cancelLabel` prop and use the common translation for "Cancel" if not provided, improving localization and flexibility. [[1]](diffhunk://#diff-d6c3e431cb18efc6e4c6e5524ac7dc4b2d5e08aa556c7ebb7ecbb22ea6f39499R4-R11) [[2]](diffhunk://#diff-d6c3e431cb18efc6e4c6e5524ac7dc4b2d5e08aa556c7ebb7ecbb22ea6f39499R22-R27) [[3]](diffhunk://#diff-d6c3e431cb18efc6e4c6e5524ac7dc4b2d5e08aa556c7ebb7ecbb22ea6f39499L63-R67)

**Internationalization:**

* Added new translation keys and values in all supported languages (`en`, `de`, `es`, `fr`, `it`, `pt`) for improved error messages and UI labels, including `invalidEmail`, `noUnitsDesc`, `completionTestTitle`, `levelTestResult`, and `testScore`. [[1]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158L83-R84) [[2]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158L285-R290) [[3]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL83-R84) [[4]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL285-R290) [[5]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2L83-R84) [[6]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2L285-R290) [[7]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877L83-R84) [[8]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877L285-R290) [[9]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778L83-R84) [[10]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778L285-R290) [[11]](diffhunk://#diff-e7f6219511cfdbf367e656ee21bf93dba648011492721e6ab7d416bdb25fae43L83-R84) [[12]](diffhunk://#diff-e7f6219511cfdbf367e656ee21bf93dba648011492721e6ab7d416bdb25fae43L247-R252)