### PR TITLE
feature: fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-05-04
+
+### Added
+- User avatar: upload (JPEG/PNG, max 2 MB), client-side resize to 1024×1024 via Canvas API, stored as base64 data URI in DB; circular avatar shown in settings, sidebar (desktop 32×32 and mobile 28×28) and chat bubbles (28×28)
+- Avatar placeholder with user initial shown when no avatar is set
+- Tutor logo (`/logo.png`) shown as avatar in chat message bubbles
+- `POST /api/auth/me/avatar` and `DELETE /api/auth/me/avatar` endpoints (FastAPI `UploadFile`, type+size validation, base64 encoding)
+- Alembic migration `0009_user_avatar.py`: adds `avatar TEXT NULL` column to `users`
+- Alembic migration `0008_cascade_delete_user.py`: adds `ON DELETE CASCADE` to all user-owned FK constraints (`flashcards`, `study_plans`, `progress`, `chat_history`, `lessons`, `exercises`), fixing silent failures when deleting a user from admin
+- Logout confirmation dialog in settings page (reuses existing `logoutConfirmTitle/Message` keys)
+- i18n keys in all 6 locales: `settings.avatarChange`, `settings.avatarRemove`, `settings.avatarUploading`, `settings.avatarTypeError`, `settings.avatarSizeError`
+- i18n keys in all 6 locales: `flashcards.refresh`, `flashcards.generateBtn`, `flashcards.cards` (for card count options: "5 cards", "10 cards", etc.)
+- i18n keys in all 6 locales: `admin.roleUser`, `admin.roleAdmin`
+- `avatar?: string | null` field added to `User` interface (frontend Zustand store) and `UserResponse` schema (backend)
+
+### Changed
+- `flashcards.noDue` translation updated to "No cards due for review" (and equivalents in all locales)
+- Flashcards page: `+ Generate` button, `{n} cards` option labels, "No cards due for review" text and "Refresh" button now use i18n keys
+- Chat sidebar: `+ New` button now uses `t('newConversation')` i18n key
+- Admin users list: role badge (`user`/`admin`) and `inactive` badge now use i18n keys instead of hardcoded English strings
+
+### Fixed
+- Admin: deleting a user now correctly removes all associated data thanks to `ON DELETE CASCADE`; delete error was previously only visible inside the create-user form panel — now shown globally
+- Login/register: raw backend validation errors (e.g. Pydantic email format messages) no longer shown to the user; all errors mapped to translated strings (`invalidEmail`, `usernameTaken`, `emailTaken`, `registrationClosed`, `invalidInvite`, generic fallback)
+- i18n keys `auth.register.usernameTaken`, `auth.register.emailTaken`, `auth.register.invalidInvite`, `auth.login.invalidEmail` added to all 6 locale files
+
 ## [1.3.0] - 2026-05-04
 
 ### Added

--- a/frontend/src/app/(app)/admin/users/page.tsx
+++ b/frontend/src/app/(app)/admin/users/page.tsx
@@ -237,9 +237,9 @@ export default function AdminUsersPage() {
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-sm text-fl-fg">{u.display_name}</span>
                     <span className={`font-mono text-fl-hint tracking-widest uppercase border px-2 py-0.5 ${u.role === 'admin' ? 'border-fl-fg/40 text-fl-fg' : 'border-fl-border text-fl-muted-2'
-                      }`}>{u.role}</span>
+                      }`}>{u.role === 'admin' ? t('roleAdmin') : t('roleUser')}</span>
                     {!u.is_active && (
-                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-fl-error/30 text-fl-error-fg px-2 py-0.5">inactive</span>
+                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-fl-error/30 text-fl-error-fg px-2 py-0.5">{t('inactive')}</span>
                     )}
                   </div>
                   <p className="font-mono text-fl-label text-fl-muted-2">

--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -194,7 +194,7 @@ export default function ChatPage() {
               className="font-mono text-fl-label tracking-widest text-fl-muted-1 hover:text-fl-fg transition-colors uppercase"
               title={t('newConversation')}
             >
-              + New
+              + {t('newConversation')}
             </button>
           </div>
           <div className="flex-1 overflow-y-auto">

--- a/frontend/src/app/(app)/flashcards/page.tsx
+++ b/frontend/src/app/(app)/flashcards/page.tsx
@@ -139,7 +139,7 @@ export default function FlashcardsPage() {
             : 'border-fl-border text-fl-muted-2 hover:text-fl-fg hover:border-fl-border-2'
             }`}
         >
-          + Generate
+          + {t('generateBtn')}
         </button>
       </div>
 
@@ -173,7 +173,7 @@ export default function FlashcardsPage() {
                   onChange={(e) => setGenCount(Number(e.target.value))}
                   className="w-full bg-fl-bg border border-fl-border px-4 py-3 font-mono text-sm text-fl-fg focus:outline-none focus:border-fl-border-2 appearance-none"
                 >
-                  {[5, 10, 15, 20].map(n => <option key={n} value={n}>{n} cards</option>)}
+                  {[5, 10, 15, 20].map(n => <option key={n} value={n}>{n} {t('cards')}</option>)}
                 </select>
               </div>
               <div>
@@ -201,7 +201,7 @@ export default function FlashcardsPage() {
       {/* No cards */}
       {cards.length === 0 && (
         <div className="border border-fl-border bg-fl-surface px-6 py-10 text-center">
-          <p className="font-mono text-sm text-fl-muted-1">No cards due for review</p>
+          <p className="font-mono text-sm text-fl-muted-1">{t('noDue')}</p>
           {total === 0 && (
             <p className="font-mono text-xs text-fl-muted-2 mt-2">Use <span className="text-fl-muted-1">+ Generate</span> to create your first cards with AI</p>
           )}
@@ -209,7 +209,7 @@ export default function FlashcardsPage() {
             onClick={loadDue}
             className="mt-6 border border-fl-border px-6 py-2 font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase hover:text-fl-fg hover:border-fl-border-2 transition-colors"
           >
-            — Refresh
+            — {t('refresh')}
           </button>
         </div>
       )}

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -222,7 +222,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.0</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.1</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -341,7 +341,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.0</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.1</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/messages/de.json
+++ b/messages/de.json
@@ -331,7 +331,7 @@
     "title": "Karteikarten",
     "due": "Fällig",
     "total": "Gesamt",
-    "noDue": "Heute keine Karteikarten fällig.",
+    "noDue": "Keine Karten zur Wiederholung fällig",
     "allCaughtUp": "Alles erledigt!",
     "generate": "Karteikarten erstellen",
     "generating": "Wird erstellt...",
@@ -350,7 +350,10 @@
     "sectionGenerate": "Neue Karten erstellen",
     "speakingMode": "Sprechen",
     "standardMode": "Standard",
-    "sayWord": "Sag das Wort laut"
+    "sayWord": "Sag das Wort laut",
+    "refresh": "Aktualisieren",
+    "generateBtn": "Generieren",
+    "cards": "Karten"
   },
   "chat": {
     "title": "KI-Tutor",
@@ -474,7 +477,9 @@
     "inviteBtn": "+ Einladungslink",
     "createUserBtn": "+ Benutzer erstellen",
     "prevPage": "← Zurück",
-    "nextPage": "Weiter →"
+    "nextPage": "Weiter →",
+    "roleUser": "Benutzer",
+    "roleAdmin": "Admin"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/en.json
+++ b/messages/en.json
@@ -331,7 +331,7 @@
     "title": "Flashcards",
     "due": "Due",
     "total": "Total",
-    "noDue": "No flashcards due today.",
+    "noDue": "No cards due for review",
     "allCaughtUp": "All caught up!",
     "generate": "Generate Flashcards",
     "generating": "Generating...",
@@ -350,7 +350,10 @@
     "sectionGenerate": "Generate New Cards",
     "speakingMode": "Speaking",
     "standardMode": "Standard",
-    "sayWord": "Say the word aloud"
+    "sayWord": "Say the word aloud",
+    "refresh": "Refresh",
+    "generateBtn": "Generate",
+    "cards": "cards"
   },
   "chat": {
     "title": "AI Tutor",
@@ -474,7 +477,9 @@
     "inviteBtn": "+ Invite Link",
     "createUserBtn": "+ Create User",
     "prevPage": "← Prev",
-    "nextPage": "Next →"
+    "nextPage": "Next →",
+    "roleUser": "User",
+    "roleAdmin": "Admin"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/es.json
+++ b/messages/es.json
@@ -331,7 +331,7 @@
     "title": "Tarjetas",
     "due": "Para hoy",
     "total": "Total",
-    "noDue": "No hay tarjetas para hoy.",
+    "noDue": "No hay tarjetas pendientes de revisión",
     "allCaughtUp": "¡Al día!",
     "generate": "Generar tarjetas",
     "generating": "Generando…",
@@ -350,7 +350,10 @@
     "sectionGenerate": "Generar nuevas tarjetas",
     "speakingMode": "Hablar",
     "standardMode": "Estándar",
-    "sayWord": "Di la palabra en voz alta"
+    "sayWord": "Di la palabra en voz alta",
+    "refresh": "Actualizar",
+    "generateBtn": "Generar",
+    "cards": "tarjetas"
   },
   "chat": {
     "title": "Tutor IA",
@@ -474,7 +477,9 @@
     "inviteBtn": "+ Enlace de invitación",
     "createUserBtn": "+ Crear usuario",
     "prevPage": "← Anterior",
-    "nextPage": "Siguiente →"
+    "nextPage": "Siguiente →",
+    "roleUser": "Usuario",
+    "roleAdmin": "Admin"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -331,7 +331,7 @@
     "title": "Fiches",
     "due": "À revoir",
     "total": "Total",
-    "noDue": "Aucune fiche à revoir aujourd'hui.",
+    "noDue": "Aucune carte à réviser",
     "allCaughtUp": "Tout est à jour !",
     "generate": "Générer des fiches",
     "generating": "Génération...",
@@ -350,7 +350,10 @@
     "sectionGenerate": "Générer de nouvelles fiches",
     "speakingMode": "Expression orale",
     "standardMode": "Standard",
-    "sayWord": "Dites le mot à voix haute"
+    "sayWord": "Dites le mot à voix haute",
+    "refresh": "Actualiser",
+    "generateBtn": "Générer",
+    "cards": "cartes"
   },
   "chat": {
     "title": "Tuteur IA",
@@ -474,7 +477,9 @@
     "inviteBtn": "+ Lien d'invitation",
     "createUserBtn": "+ Créer un utilisateur",
     "prevPage": "← Préc.",
-    "nextPage": "Suiv. →"
+    "nextPage": "Suiv. →",
+    "roleUser": "Utilisateur",
+    "roleAdmin": "Admin"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/it.json
+++ b/messages/it.json
@@ -331,7 +331,7 @@
     "title": "Schede",
     "due": "Da rivedere",
     "total": "Totale",
-    "noDue": "Nessuna scheda da rivedere oggi.",
+    "noDue": "Nessuna carta da ripassare",
     "allCaughtUp": "Tutto in regola!",
     "generate": "Genera schede",
     "generating": "Generazione...",
@@ -350,7 +350,10 @@
     "sectionGenerate": "Genera nuove schede",
     "speakingMode": "Parlato",
     "standardMode": "Standard",
-    "sayWord": "Di' la parola ad alta voce"
+    "sayWord": "Di' la parola ad alta voce",
+    "refresh": "Aggiorna",
+    "generateBtn": "Genera",
+    "cards": "carte"
   },
   "chat": {
     "title": "Tutor IA",
@@ -474,7 +477,9 @@
     "inviteBtn": "+ Link di invito",
     "createUserBtn": "+ Crea utente",
     "prevPage": "← Prec.",
-    "nextPage": "Succ. →"
+    "nextPage": "Succ. →",
+    "roleUser": "Utente",
+    "roleAdmin": "Admin"
   },
   "faq": {
     "title": "FAQ",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -293,7 +293,7 @@
     "title": "Cartões",
     "due": "Para hoje",
     "total": "Total",
-    "noDue": "Nenhum cartão para hoje.",
+    "noDue": "Nenhum cartão para revisão",
     "allCaughtUp": "Tudo em dia!",
     "generate": "Gerar cartões",
     "generating": "Gerando...",
@@ -312,7 +312,10 @@
     "sectionGenerate": "Gerar novos cartões",
     "speakingMode": "Fala",
     "standardMode": "Padrão",
-    "sayWord": "Diga a palavra em voz alta"
+    "sayWord": "Diga a palavra em voz alta",
+    "refresh": "Atualizar",
+    "generateBtn": "Gerar",
+    "cards": "cartas"
   },
   "chat": {
     "title": "Tutor IA",
@@ -436,7 +439,9 @@
     "inviteBtn": "+ Link de convite",
     "createUserBtn": "+ Criar utilizador",
     "prevPage": "← Anterior",
-    "nextPage": "Seguinte →"
+    "nextPage": "Seguinte →",
+    "roleUser": "Usuário",
+    "roleAdmin": "Admin"
   },
   "faq": {
     "title": "FAQ",

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.3.0**
+**1.3.1**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request updates the application to version 1.3.1, focusing on improving internationalization (i18n) and user interface consistency across the flashcards, chat, and admin user management pages. It introduces new i18n keys and replaces hardcoded strings with translated keys in the UI, ensuring all supported languages display consistent and localized messages. The version number is also incremented throughout the project files.

**Internationalization improvements:**

* Added new i18n keys for flashcards (`refresh`, `generateBtn`, `cards`, and updated `noDue`), admin roles (`roleUser`, `roleAdmin`), and other UI elements in all six supported locales. [[1]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158L353-R356) [[2]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158L477-R482) [[3]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL353-R356) [[4]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL477-R482) [[5]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2L353-R356) [[6]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2L477-R482) [[7]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877L353-R356) [[8]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877L477-R482) [[9]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778L353-R356) [[10]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778L477-R482) [[11]](diffhunk://#diff-e7f6219511cfdbf367e656ee21bf93dba648011492721e6ab7d416bdb25fae43L315-R318) [[12]](diffhunk://#diff-e7f6219511cfdbf367e656ee21bf93dba648011492721e6ab7d416bdb25fae43L439-R444)
* Updated translations for "No cards due for review" in all locales for consistency. [[1]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158L334-R334) [[2]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL334-R334) [[3]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2L334-R334) [[4]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877L334-R334) [[5]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778L334-R334) [[6]](diffhunk://#diff-e7f6219511cfdbf367e656ee21bf93dba648011492721e6ab7d416bdb25fae43L296-R296)

**UI and code changes to use i18n keys:**

* Flashcards page: replaced hardcoded labels for generate button, card count options, "No cards due for review" message, and refresh button with i18n keys. [[1]](diffhunk://#diff-af0d25160635c4544e18bb0399738351cfc399ce9ac87ae6346f374905ad6d30L142-R142) [[2]](diffhunk://#diff-af0d25160635c4544e18bb0399738351cfc399ce9ac87ae6346f374905ad6d30L176-R176) [[3]](diffhunk://#diff-af0d25160635c4544e18bb0399738351cfc399ce9ac87ae6346f374905ad6d30L204-R212)
* Chat sidebar: replaced "+ New" button label with i18n key.
* Admin users list: replaced hardcoded role and inactive status badges with i18n keys.

**Version bump:**

* Updated version references from 1.3.0 to 1.3.1 in UI and documentation files. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L225-R225) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L344-R344) [[3]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R33)

**Documentation:**

* Added a new changelog entry for version 1.3.1 summarizing all these changes and additional backend/API improvements not shown in this diff.