### PR TITLE
feature: fixes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/pr-develop-checks.yml
+++ b/.github/workflows/pr-develop-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: backend/requirements.txt
 

--- a/.github/workflows/pr-develop-checks.yml
+++ b/.github/workflows/pr-develop-checks.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/release-from-changelog.yml
+++ b/.github/workflows/release-from-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## Architecture at a glance
 
-Monorepo: `backend/` (Python 3.12 FastAPI) + `frontend/` (Next.js 16 App Router) deployed via Docker Compose with PostgreSQL 16 and Redis 7. The backend proxies all external services (Ollama, Kokoro, Whisper) — the frontend never calls them directly.
+Monorepo: `backend/` (Python 3.14 FastAPI) + `frontend/` (Next.js 16 App Router) deployed via Docker Compose with PostgreSQL 16 and Redis 7. The backend proxies all external services (Ollama, Kokoro, Whisper) — the frontend never calls them directly.
 
 ## Key constraints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-05-05
+
+### Added
+- Button "Continue in voice" in the AI tutor chat header: appears when a conversation has messages and is idle (not sending). Clicking it serialises up to the last 20 non-empty messages into `sessionStorage` and navigates to the real-time voice conversation page
+- Voice conversation page reads and clears the `voice_context` key from `sessionStorage` on mount and passes it to `ConversationMode` as `initialContext`
+- `ConversationMode` accepts optional `initialContext` prop and includes it in the WebSocket auth handshake payload when present
+- Backend WebSocket endpoint extracts and sanitises the optional `context` field from the auth message (max 20 entries, valid roles, non-empty content) and passes it to `ConversationPipeline`
+- `ConversationPipeline` accepts `initial_context` parameter and pre-populates `self.history` with up to the last 10 valid turns, so the AI continues the text-based tutoring session seamlessly in voice
+- `ChatContextItem` TypeScript interface exported from `lib/conversation-ws.ts`
+- i18n key `chat.continueInVoice` added to all 6 locale files (EN, ES, FR, DE, IT, PT)
+- 8 new unit tests for `ConversationPipeline.initial_context`: covers empty/None input, valid population, truncation to 10, invalid-role filtering, empty-content filtering, non-dict entry filtering, and extra-key stripping
+
 ## [1.3.2] - 2026-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![License](https://img.shields.io/badge/license-AGPL%20v3-blue?style=flat-square)
 ![Next.js](https://img.shields.io/badge/next.js-16-black?style=flat-square)
-![Python](https://img.shields.io/badge/python-3.12-blue?style=flat-square)
+![Python](https://img.shields.io/badge/python-3.14-blue?style=flat-square)
 ![Self-hosted](https://img.shields.io/badge/self--hosted-yes-orange?style=flat-square)
 
 <p align="left">

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/backend/app/routers/conversation.py
+++ b/backend/app/routers/conversation.py
@@ -26,9 +26,11 @@ async def conversation_ws(
     # --- Accept first, then authenticate via first JSON message ---
     await websocket.accept()
 
+    initial_context_raw: list | None = None
     try:
         auth_msg = await asyncio.wait_for(websocket.receive_json(), timeout=10.0)
         token = auth_msg.get("token", "")
+        initial_context_raw = auth_msg.get("context")  # optional chat history
         payload = decode_access_token(token)
         user_id = int(payload["sub"])
     except (asyncio.TimeoutError, PyJWTError, KeyError, ValueError, Exception):
@@ -73,8 +75,22 @@ async def conversation_ws(
         native_language = user.native_language
         target_language = user.target_language
 
-    logger.info("[conversation] Session started — user=%s cefr=%s max_duration=%ss inactivity=%ss",
-                user_id, cefr_level, max_duration, inactivity_timeout)
+    # Validate and sanitize optional chat context passed from the tutor chat
+    valid_context: list[dict] | None = None
+    if isinstance(initial_context_raw, list):
+        sanitized = [
+            {"role": m["role"], "content": m["content"]}
+            for m in initial_context_raw[:20]
+            if isinstance(m, dict)
+            and m.get("role") in ("user", "assistant")
+            and isinstance(m.get("content"), str)
+            and m["content"].strip()
+        ]
+        if sanitized:
+            valid_context = sanitized
+
+    logger.info("[conversation] Session started — user=%s cefr=%s max_duration=%ss inactivity=%ss context_turns=%s",
+                user_id, cefr_level, max_duration, inactivity_timeout, len(valid_context) if valid_context else 0)
     # (already accepted at the top)
 
     pipeline = ConversationPipeline(
@@ -86,6 +102,7 @@ async def conversation_ws(
         target_language=target_language,
         max_duration=max_duration,
         inactivity_timeout=inactivity_timeout,
+        initial_context=valid_context,
     )
 
     try:

--- a/backend/app/services/conversation_pipeline.py
+++ b/backend/app/services/conversation_pipeline.py
@@ -54,6 +54,7 @@ class ConversationPipeline:
         target_language: str = "en-US",
         max_duration: int = 1800,
         inactivity_timeout: int = 180,
+        initial_context: list[dict] | None = None,
     ) -> None:
         self.llm = llm
         self.tts = tts
@@ -68,7 +69,18 @@ class ConversationPipeline:
         self.inactivity_timeout = inactivity_timeout
 
         self.current_task: asyncio.Task | None = None
-        self.history: list[dict] = []
+        # Pre-populate history from optional chat context
+        if initial_context:
+            self.history: list[dict] = [
+                {"role": m["role"], "content": m["content"]}
+                for m in initial_context
+                if isinstance(m, dict)
+                and m.get("role") in ("user", "assistant")
+                and isinstance(m.get("content"), str)
+                and m["content"].strip()
+            ][-10:]
+        else:
+            self.history = []
         self._session_start = time.monotonic()
         self._last_activity = time.monotonic()
         self._timer_tasks: list[asyncio.Task] = []

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py311"
+target-version = "py314"
 line-length = 100
 
 [tool.ruff.lint]
@@ -17,7 +17,7 @@ ignore = ["ANN101", "S101", "B008", "UP017"]
 
 [tool.black]
 line-length = 100
-target-version = ["py311"]
+target-version = ["py314"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/tests/test_conversation.py
+++ b/backend/tests/test_conversation.py
@@ -245,3 +245,124 @@ async def test_pipeline_stt_failure_sends_error_frame() -> None:
 
     codes = [m.get("code") for m in sent if m.get("type") == "error"]
     assert "stt_failed" in codes
+
+
+# ---------------------------------------------------------------------------
+# ConversationPipeline — initial_context tests
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline(**kwargs) -> "ConversationPipeline":
+    from app.services.conversation_pipeline import ConversationPipeline
+
+    return ConversationPipeline(
+        llm=AsyncMock(),
+        tts=AsyncMock(),
+        stt=AsyncMock(),
+        cefr_level="B1",
+        max_duration=1800,
+        inactivity_timeout=180,
+        **kwargs,
+    )
+
+
+def test_pipeline_initial_context_none_gives_empty_history() -> None:
+    """No initial_context → empty history list."""
+    pipeline = _make_pipeline()
+    assert pipeline.history == []
+
+
+def test_pipeline_initial_context_empty_list_gives_empty_history() -> None:
+    """Empty list initial_context → empty history list."""
+    pipeline = _make_pipeline(initial_context=[])
+    assert pipeline.history == []
+
+
+def test_pipeline_initial_context_valid_entries_populate_history() -> None:
+    """Valid initial_context entries are copied verbatim into history."""
+    context = [
+        {"role": "user", "content": "Hello, can you help me?"},
+        {"role": "assistant", "content": "Of course! What would you like to practice?"},
+        {"role": "user", "content": "I want to work on past tense."},
+    ]
+    pipeline = _make_pipeline(initial_context=context)
+    assert len(pipeline.history) == 3
+    assert pipeline.history[0] == {"role": "user", "content": "Hello, can you help me?"}
+    assert pipeline.history[2] == {"role": "user", "content": "I want to work on past tense."}
+
+
+def test_pipeline_initial_context_truncates_to_last_10() -> None:
+    """When initial_context has more than 10 valid entries, only the last 10 are kept."""
+    context = [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"Message {i}"}
+        for i in range(14)
+    ]
+    pipeline = _make_pipeline(initial_context=context)
+    assert len(pipeline.history) == 10
+    # The last 10 items of the original list (indices 4-13) must be preserved in order
+    expected_contents = [f"Message {i}" for i in range(4, 14)]
+    actual_contents = [m["content"] for m in pipeline.history]
+    assert actual_contents == expected_contents
+
+
+def test_pipeline_initial_context_filters_invalid_role() -> None:
+    """Entries with unrecognised roles are silently dropped."""
+    context = [
+        {"role": "system", "content": "You are a bot."},  # invalid role
+        {"role": "user", "content": "Hello there!"},
+        {"role": "moderator", "content": "Be nice."},  # invalid role
+        {"role": "assistant", "content": "Hi!"},
+    ]
+    pipeline = _make_pipeline(initial_context=context)
+    assert len(pipeline.history) == 2
+    assert pipeline.history[0]["role"] == "user"
+    assert pipeline.history[1]["role"] == "assistant"
+
+
+def test_pipeline_initial_context_filters_empty_content() -> None:
+    """Entries with empty or whitespace-only content are silently dropped."""
+    context = [
+        {"role": "user", "content": ""},
+        {"role": "user", "content": "   "},
+        {"role": "assistant", "content": "Hello!"},
+        {"role": "user", "content": "\n\t"},
+    ]
+    pipeline = _make_pipeline(initial_context=context)
+    assert len(pipeline.history) == 1
+    assert pipeline.history[0]["content"] == "Hello!"
+
+
+def test_pipeline_initial_context_filters_non_dict_entries() -> None:
+    """Non-dict entries (strings, ints, None) in initial_context are ignored."""
+    context = [
+        "not a dict",
+        42,
+        None,
+        {"role": "user", "content": "This is valid."},
+    ]
+    pipeline = _make_pipeline(initial_context=context)  # type: ignore[arg-type]
+    assert len(pipeline.history) == 1
+    assert pipeline.history[0]["content"] == "This is valid."
+
+
+def test_pipeline_initial_context_does_not_leak_extra_keys() -> None:
+    """Extra keys in initial_context entries are stripped — only role/content survive."""
+    context = [
+        {"role": "user", "content": "Hi!", "id": 99, "timestamp": "2026-01-01"},
+        {"role": "assistant", "content": "Hey there!", "metadata": {"foo": "bar"}},
+    ]
+    pipeline = _make_pipeline(initial_context=context)
+    assert len(pipeline.history) == 2
+    for entry in pipeline.history:
+        assert set(entry.keys()) == {"role", "content"}
+
+
+def test_pipeline_initial_context_history_is_used_in_subsequent_turns() -> None:
+    """After pre-populating, normal _add_to_history appends to existing entries."""
+    context = [{"role": "user", "content": "Tell me about cats."}]
+    pipeline = _make_pipeline(initial_context=context)
+    # Simulate what the pipeline does after a user turn: append to history
+    pipeline.history.append({"role": "assistant", "content": "Cats are fascinating!"})
+    assert len(pipeline.history) == 2
+    assert pipeline.history[0]["role"] == "user"
+    assert pipeline.history[1]["role"] == "assistant"

--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -287,7 +287,7 @@ export default function ChatPage() {
                   {msg.role === 'assistant' ? (
                     <Image src="/logo.png" alt="Tutor" width={28} height={28} className="w-full h-full object-cover" />
                   ) : user?.avatar ? (
-                    <img src={user.avatar} alt="" className="w-full h-full object-cover" />
+                    <Image src={user.avatar} alt="" width={28} height={28} className="w-full h-full object-cover" unoptimized />
                   ) : (
                     <div className="w-full h-full bg-fl-surface-2 flex items-center justify-center">
                       <span className="font-mono text-fl-hint text-fl-muted-1 select-none">

--- a/frontend/src/app/(app)/chat/page.tsx
+++ b/frontend/src/app/(app)/chat/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { apiFetch } from '@/lib/api'
@@ -23,6 +24,7 @@ interface Conversation {
 export default function ChatPage() {
   const t = useTranslations('chat')
   const tCommon = useTranslations('common')
+  const router = useRouter()
   const user = useAuthStore((s) => s.user)
   const [conversations, setConversations] = useState<Conversation[]>([])
   const [activeId, setActiveId] = useState<number | null>(null)
@@ -95,6 +97,14 @@ export default function ChatPage() {
     setMessages([])
     setError('')
     inputRef.current?.focus()
+  }
+
+  function continueInVoice() {
+    const context = messages
+      .filter((m) => m.content.trim().length > 0)
+      .slice(-20)
+    sessionStorage.setItem('voice_context', JSON.stringify(context))
+    router.push('/conversation')
   }
 
   async function deleteConversation(id: number) {
@@ -244,9 +254,16 @@ export default function ChatPage() {
               ? (conversations.find((c) => c.id === activeId)?.title ?? t('title'))
               : t('newConversation')}
           </span>
-          {sending && (
+          {sending ? (
             <span className="ml-auto font-mono text-fl-hint tracking-widest text-fl-muted-3 uppercase animate-pulse">{t('thinking')}</span>
-          )}
+          ) : messages.length > 0 ? (
+            <button
+              onClick={continueInVoice}
+              className="ml-auto font-mono text-fl-hint tracking-widest text-fl-muted-2 hover:text-fl-fg uppercase transition-colors"
+            >
+              {t('continueInVoice')}
+            </button>
+          ) : null}
         </div>
 
         {/* Messages */}

--- a/frontend/src/app/(app)/conversation/page.tsx
+++ b/frontend/src/app/(app)/conversation/page.tsx
@@ -7,7 +7,9 @@
  */
 'use client'
 
+import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
+import type { ChatContextItem } from '@/lib/conversation-ws'
 
 const ConversationMode = dynamic(
   () => import('@/components/conversation/ConversationMode'),
@@ -24,5 +26,22 @@ const ConversationMode = dynamic(
 )
 
 export default function ConversationPage() {
-  return <ConversationMode />
+  const [initialContext, setInitialContext] = useState<ChatContextItem[] | undefined>(undefined)
+
+  useEffect(() => {
+    const raw = sessionStorage.getItem('voice_context')
+    if (raw) {
+      sessionStorage.removeItem('voice_context')
+      try {
+        const parsed = JSON.parse(raw) as unknown
+        if (Array.isArray(parsed)) {
+          setInitialContext(parsed as ChatContextItem[])
+        }
+      } catch {
+        // malformed — ignore
+      }
+    }
+  }, [])
+
+  return <ConversationMode initialContext={initialContext} />
 }

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { useAuthStore } from '@/store/auth'
 import { apiFetch } from '@/lib/api'
+import Image from 'next/image'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { LoadingBar } from '@/components/ui/loading-bar'
 
@@ -206,7 +207,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           <div className="flex items-center gap-3 mb-3">
             <div className="w-8 h-8 rounded-full overflow-hidden border border-fl-border flex-shrink-0">
               {user?.avatar ? (
-                <img src={user.avatar} alt="" className="w-full h-full object-cover" />
+                <Image src={user.avatar} alt="" width={32} height={32} className="w-full h-full object-cover" unoptimized />
               ) : (
                 <div className="w-full h-full bg-fl-surface-2 flex items-center justify-center">
                   <span className="font-mono text-xs text-fl-muted-1 select-none">
@@ -330,7 +331,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <div className="flex items-center gap-3 mb-2">
                 <div className="w-7 h-7 rounded-full overflow-hidden border border-fl-border flex-shrink-0">
                   {user?.avatar ? (
-                    <img src={user.avatar} alt="" className="w-full h-full object-cover" />
+                    <Image src={user.avatar} alt="" width={28} height={28} className="w-full h-full object-cover" unoptimized />
                   ) : (
                     <div className="w-full h-full bg-fl-surface-2 flex items-center justify-center">
                       <span className="font-mono text-fl-hint text-fl-muted-1 select-none">

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -222,7 +222,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.2</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.3</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -341,7 +341,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.2</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.3</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -6,6 +6,7 @@ import { apiFetch } from '@/lib/api'
 import { useAuthStore } from '@/store/auth'
 import { useThemeStore } from '@/store/theme'
 import { useRouter } from 'next/navigation'
+import NextImage from 'next/image'
 import { ExternalLink } from 'lucide-react'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 
@@ -212,7 +213,7 @@ export default function SettingsPage() {
             className="relative flex-shrink-0 w-16 h-16 rounded-full overflow-hidden border border-fl-border hover:border-fl-border-2 transition-colors focus:outline-none disabled:opacity-60"
           >
             {user?.avatar ? (
-              <img src={user.avatar} alt="" className="w-full h-full object-cover" />
+              <NextImage src={user.avatar} alt="" width={64} height={64} className="w-full h-full object-cover" unoptimized />
             ) : (
               <div className="w-full h-full bg-fl-surface-2 flex items-center justify-center">
                 <span className="font-mono text-xl text-fl-muted-1 select-none">

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -454,21 +454,15 @@ export default function SettingsPage() {
         </div>
         <div className="flex flex-col gap-2">
           <a
-            href="/terms"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors"
+            href="/terms?from=settings"
+            className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors"
           >
-            <ExternalLink className="w-3.5 h-3.5" />
             {t('termsOfService')}
           </a>
           <a
-            href="/privacy"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors"
+            href="/privacy?from=settings"
+            className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors"
           >
-            <ExternalLink className="w-3.5 h-3.5" />
             {t('privacyPolicy')}
           </a>
         </div>

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -143,9 +143,9 @@ function RegisterForm() {
               />
               <label htmlFor="terms-accept" className="font-mono text-xs text-fl-muted-2 leading-relaxed cursor-pointer select-none">
                 {t('termsAccept')}{' '}
-                <a href="/terms" target="_blank" rel="noopener noreferrer" className="text-fl-muted-1 hover:text-fl-fg underline underline-offset-2 transition-colors">{t('termsLink')}</a>
+                <a href="/terms?from=register" className="text-fl-muted-1 hover:text-fl-fg underline underline-offset-2 transition-colors">{t('termsLink')}</a>
                 {' '}{t('andWord')}{' '}
-                <a href="/privacy" target="_blank" rel="noopener noreferrer" className="text-fl-muted-1 hover:text-fl-fg underline underline-offset-2 transition-colors">{t('privacyLink')}</a>
+                <a href="/privacy?from=register" className="text-fl-muted-1 hover:text-fl-fg underline underline-offset-2 transition-colors">{t('privacyLink')}</a>
               </label>
             </div>
 

--- a/frontend/src/app/(legal)/privacy/page.tsx
+++ b/frontend/src/app/(legal)/privacy/page.tsx
@@ -3,9 +3,16 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
+import { useSearchParams } from 'next/navigation'
 
 export default function PrivacyPage() {
   const t = useTranslations('legal.privacy')
+  const searchParams = useSearchParams()
+  const from = searchParams.get('from')
+  const isFromSettings = from === 'settings'
+  const backHref = isFromSettings ? '/settings' : '/register'
+  const backLabel = isFromSettings ? t('linkBackSettings') : t('linkBack')
+  const termsHref = isFromSettings ? '/terms?from=settings' : '/terms'
   const s2Items = [t('s2i1'), t('s2i2'), t('s2i3'), t('s2i4'), t('s2i5'), t('s2i6'), t('s2i7')]
   const s3Items = [t('s3i1'), t('s3i2'), t('s3i3'), t('s3i4')]
 
@@ -72,11 +79,11 @@ export default function PrivacyPage() {
         ))}
 
         <div className="pt-4 border-t border-fl-border flex gap-6">
-          <Link href="/terms" className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors">
+          <Link href={termsHref} className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors">
             — {t('linkTerms')}
           </Link>
-          <Link href="/register" className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors">
-            — {t('linkBack')}
+          <Link href={backHref} className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors">
+            — {backLabel}
           </Link>
         </div>
       </div>

--- a/frontend/src/app/(legal)/terms/page.tsx
+++ b/frontend/src/app/(legal)/terms/page.tsx
@@ -3,9 +3,16 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
+import { useSearchParams } from 'next/navigation'
 
 export default function TermsPage() {
   const t = useTranslations('legal.terms')
+  const searchParams = useSearchParams()
+  const from = searchParams.get('from')
+  const isFromSettings = from === 'settings'
+  const backHref = isFromSettings ? '/settings' : '/register'
+  const backLabel = isFromSettings ? t('linkBackSettings') : t('linkBack')
+  const privacyHref = isFromSettings ? '/privacy?from=settings' : '/privacy'
   const s2Items = [t('s2i1'), t('s2i2'), t('s2i3'), t('s2i4')]
 
   return (
@@ -59,11 +66,11 @@ export default function TermsPage() {
         ))}
 
         <div className="pt-4 border-t border-fl-border flex gap-6">
-          <Link href="/privacy" className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors">
+          <Link href={privacyHref} className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors">
             — {t('linkPrivacy')}
           </Link>
-          <Link href="/register" className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors">
-            — {t('linkBack')}
+          <Link href={backHref} className="font-mono text-xs text-fl-muted-2 hover:text-fl-fg tracking-widest uppercase transition-colors">
+            — {backLabel}
           </Link>
         </div>
       </div>

--- a/frontend/src/components/conversation/ConversationMode.tsx
+++ b/frontend/src/components/conversation/ConversationMode.tsx
@@ -5,7 +5,7 @@ import { useMicVAD } from '@ricky0123/vad-react'
 import { useTranslations } from 'next-intl'
 import { useAuthStore } from '@/store/auth'
 import { float32ToWav, createAudioQueue, type AudioQueue } from '@/lib/audio'
-import { buildConversationWsUrl, type WsMessage } from '@/lib/conversation-ws'
+import { buildConversationWsUrl, type WsMessage, type ChatContextItem } from '@/lib/conversation-ws'
 import StatusIndicator, { type ConvStatus } from './StatusIndicator'
 import TranscriptBubble from './TranscriptBubble'
 import SessionTimeoutBanner from './SessionTimeoutBanner'
@@ -17,7 +17,7 @@ interface TranscriptEntry {
   text: string
 }
 
-export default function ConversationMode() {
+export default function ConversationMode({ initialContext }: { initialContext?: ChatContextItem[] }) {
   const t = useTranslations('conversation')
   const accessToken = useAuthStore((s) => s.accessToken)
 
@@ -93,14 +93,16 @@ export default function ConversationMode() {
 
   // ─── WebSocket ────────────────────────────────────────────────────────────
   const connectWs = useCallback(
-    (token: string) => {
+    (token: string, context?: ChatContextItem[]) => {
       const url = buildConversationWsUrl()
       const ws = new WebSocket(url)
       ws.binaryType = 'arraybuffer'
       wsRef.current = ws
 
       ws.onopen = () => {
-        ws.send(JSON.stringify({ type: 'auth', token }))
+        const authPayload: Record<string, unknown> = { type: 'auth', token }
+        if (context?.length) authPayload.context = context
+        ws.send(JSON.stringify(authPayload))
         setStatus('live')
       }
 
@@ -223,7 +225,7 @@ export default function ConversationMode() {
       setSessionActive(false)
     })
 
-    connectWs(accessToken)
+    connectWs(accessToken, initialContext)
   }
 
   function handleStop() {

--- a/frontend/src/lib/conversation-ws.ts
+++ b/frontend/src/lib/conversation-ws.ts
@@ -62,3 +62,10 @@ export type WsMessage =
   | SessionWarningMessage
   | SessionEndMessage
   | ErrorMessage
+
+// ─── Chat context passed from tutor chat to voice session ────────────────────
+
+export interface ChatContextItem {
+  role: 'user' | 'assistant'
+  content: string
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -171,7 +171,8 @@
       "s8Title": "8. Änderungen dieser Bedingungen",
       "s8Body": "Diese Bedingungen können jederzeit aktualisiert werden. Die fortgesetzte Nutzung des Dienstes nach Änderungen gilt als Zustimmung zu den überarbeiteten Bedingungen.",
       "linkPrivacy": "Datenschutzerklärung",
-      "linkBack": "Zurück zur Registrierung"
+      "linkBack": "Zurück zur Registrierung",
+    "linkBackSettings": "Zurück zu Einstellungen"
     },
     "privacy": {
       "pageTitle": "Datenschutzerklärung",
@@ -203,7 +204,8 @@
       "s7Title": "7. Kontakt",
       "s7Body": "Bei Datenschutzfragen zu dieser spezifischen Instanz wenden Sie sich bitte an den Administrator des von Ihnen genutzten Servers. Bei Fragen zum FreeLingo-Projekt selbst besuchen Sie das Projekt-Repository auf GitHub.",
       "linkTerms": "Nutzungsbedingungen",
-      "linkBack": "Zurück zur Registrierung"
+      "linkBack": "Zurück zur Registrierung",
+    "linkBackSettings": "Zurück zu Einstellungen"
     }
   },
   "dashboard": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -172,7 +172,7 @@
       "s8Body": "Diese Bedingungen können jederzeit aktualisiert werden. Die fortgesetzte Nutzung des Dienstes nach Änderungen gilt als Zustimmung zu den überarbeiteten Bedingungen.",
       "linkPrivacy": "Datenschutzerklärung",
       "linkBack": "Zurück zur Registrierung",
-    "linkBackSettings": "Zurück zu Einstellungen"
+      "linkBackSettings": "Zurück zu Einstellungen"
     },
     "privacy": {
       "pageTitle": "Datenschutzerklärung",
@@ -205,7 +205,7 @@
       "s7Body": "Bei Datenschutzfragen zu dieser spezifischen Instanz wenden Sie sich bitte an den Administrator des von Ihnen genutzten Servers. Bei Fragen zum FreeLingo-Projekt selbst besuchen Sie das Projekt-Repository auf GitHub.",
       "linkTerms": "Nutzungsbedingungen",
       "linkBack": "Zurück zur Registrierung",
-    "linkBackSettings": "Zurück zu Einstellungen"
+      "linkBackSettings": "Zurück zu Einstellungen"
     }
   },
   "dashboard": {
@@ -440,7 +440,8 @@
     "deleteTitle": "Chat löschen",
     "deleteMessage": "Dieses Gespräch wird dauerhaft gelöscht.",
     "deleteConfirm": "Löschen",
-    "enterToSend": "Enter zum Senden"
+    "enterToSend": "Enter zum Senden",
+    "continueInVoice": "Mit Sprache fortfahren"
   },
   "progress": {
     "title": "Fortschritt",

--- a/messages/en.json
+++ b/messages/en.json
@@ -172,7 +172,7 @@
       "s8Body": "These terms may be updated at any time. Continued use of the service after changes constitutes acceptance of the revised terms.",
       "linkPrivacy": "Privacy Policy",
       "linkBack": "Back to Register",
-    "linkBackSettings": "Back to Settings"
+      "linkBackSettings": "Back to Settings"
     },
     "privacy": {
       "pageTitle": "Privacy Policy",
@@ -205,7 +205,7 @@
       "s7Body": "For any privacy-related concerns about this specific instance, please contact the administrator of the server you are using. For questions about the FreeLingo project itself, visit the project repository on GitHub.",
       "linkTerms": "Terms of Service",
       "linkBack": "Back to Register",
-    "linkBackSettings": "Back to Settings"
+      "linkBackSettings": "Back to Settings"
     }
   },
   "dashboard": {
@@ -440,7 +440,8 @@
     "deleteTitle": "Delete Chat",
     "deleteMessage": "This conversation will be permanently deleted.",
     "deleteConfirm": "Delete",
-    "enterToSend": "Enter to send"
+    "enterToSend": "Enter to send",
+    "continueInVoice": "Continue in voice"
   },
   "progress": {
     "title": "Progress",

--- a/messages/en.json
+++ b/messages/en.json
@@ -171,7 +171,8 @@
       "s8Title": "8. Changes to These Terms",
       "s8Body": "These terms may be updated at any time. Continued use of the service after changes constitutes acceptance of the revised terms.",
       "linkPrivacy": "Privacy Policy",
-      "linkBack": "Back to Register"
+      "linkBack": "Back to Register",
+    "linkBackSettings": "Back to Settings"
     },
     "privacy": {
       "pageTitle": "Privacy Policy",
@@ -203,7 +204,8 @@
       "s7Title": "7. Contact",
       "s7Body": "For any privacy-related concerns about this specific instance, please contact the administrator of the server you are using. For questions about the FreeLingo project itself, visit the project repository on GitHub.",
       "linkTerms": "Terms of Service",
-      "linkBack": "Back to Register"
+      "linkBack": "Back to Register",
+    "linkBackSettings": "Back to Settings"
     }
   },
   "dashboard": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -171,7 +171,8 @@
       "s8Title": "8. Cambios en estos Términos",
       "s8Body": "Estos términos pueden actualizarse en cualquier momento. El uso continuado del servicio tras los cambios implica la aceptación de los términos revisados.",
       "linkPrivacy": "Política de Privacidad",
-      "linkBack": "Volver al registro"
+      "linkBack": "Volver al registro",
+    "linkBackSettings": "Volver a ajustes"
     },
     "privacy": {
       "pageTitle": "Política de Privacidad",
@@ -203,7 +204,8 @@
       "s7Title": "7. Contacto",
       "s7Body": "Para cualquier consulta relacionada con la privacidad de esta instancia específica, contacta con el administrador del servidor que estás utilizando. Para preguntas sobre el proyecto FreeLingo en sí, visita el repositorio del proyecto en GitHub.",
       "linkTerms": "Términos de Servicio",
-      "linkBack": "Volver al registro"
+      "linkBack": "Volver al registro",
+    "linkBackSettings": "Volver a ajustes"
     }
   },
   "dashboard": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -172,7 +172,7 @@
       "s8Body": "Estos términos pueden actualizarse en cualquier momento. El uso continuado del servicio tras los cambios implica la aceptación de los términos revisados.",
       "linkPrivacy": "Política de Privacidad",
       "linkBack": "Volver al registro",
-    "linkBackSettings": "Volver a ajustes"
+      "linkBackSettings": "Volver a ajustes"
     },
     "privacy": {
       "pageTitle": "Política de Privacidad",
@@ -205,7 +205,7 @@
       "s7Body": "Para cualquier consulta relacionada con la privacidad de esta instancia específica, contacta con el administrador del servidor que estás utilizando. Para preguntas sobre el proyecto FreeLingo en sí, visita el repositorio del proyecto en GitHub.",
       "linkTerms": "Términos de Servicio",
       "linkBack": "Volver al registro",
-    "linkBackSettings": "Volver a ajustes"
+      "linkBackSettings": "Volver a ajustes"
     }
   },
   "dashboard": {
@@ -440,7 +440,8 @@
     "deleteTitle": "Eliminar chat",
     "deleteMessage": "Esta conversación se eliminará permanentemente.",
     "deleteConfirm": "Eliminar",
-    "enterToSend": "Intro para enviar"
+    "enterToSend": "Intro para enviar",
+    "continueInVoice": "Continuar en voz"
   },
   "progress": {
     "title": "Progreso",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -171,7 +171,8 @@
       "s8Title": "8. Modifications des Conditions",
       "s8Body": "Ces conditions peuvent être mises à jour à tout moment. L'utilisation continue du service après les modifications constitue une acceptation des conditions révisées.",
       "linkPrivacy": "Politique de confidentialité",
-      "linkBack": "Retour à l'inscription"
+      "linkBack": "Retour à l'inscription",
+    "linkBackSettings": "Retour aux paramètres"
     },
     "privacy": {
       "pageTitle": "Politique de confidentialité",
@@ -203,7 +204,8 @@
       "s7Title": "7. Contact",
       "s7Body": "Pour toute question relative à la confidentialité de cette instance spécifique, veuillez contacter l'administrateur du serveur que vous utilisez. Pour des questions sur le projet FreeLingo lui-même, visitez le dépôt du projet sur GitHub.",
       "linkTerms": "Conditions d'utilisation",
-      "linkBack": "Retour à l'inscription"
+      "linkBack": "Retour à l'inscription",
+    "linkBackSettings": "Retour aux paramètres"
     }
   },
   "dashboard": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -172,7 +172,7 @@
       "s8Body": "Ces conditions peuvent être mises à jour à tout moment. L'utilisation continue du service après les modifications constitue une acceptation des conditions révisées.",
       "linkPrivacy": "Politique de confidentialité",
       "linkBack": "Retour à l'inscription",
-    "linkBackSettings": "Retour aux paramètres"
+      "linkBackSettings": "Retour aux paramètres"
     },
     "privacy": {
       "pageTitle": "Politique de confidentialité",
@@ -205,7 +205,7 @@
       "s7Body": "Pour toute question relative à la confidentialité de cette instance spécifique, veuillez contacter l'administrateur du serveur que vous utilisez. Pour des questions sur le projet FreeLingo lui-même, visitez le dépôt du projet sur GitHub.",
       "linkTerms": "Conditions d'utilisation",
       "linkBack": "Retour à l'inscription",
-    "linkBackSettings": "Retour aux paramètres"
+      "linkBackSettings": "Retour aux paramètres"
     }
   },
   "dashboard": {
@@ -440,7 +440,8 @@
     "deleteTitle": "Supprimer le chat",
     "deleteMessage": "Cette conversation sera définitivement supprimée.",
     "deleteConfirm": "Supprimer",
-    "enterToSend": "Entrée pour envoyer"
+    "enterToSend": "Entrée pour envoyer",
+    "continueInVoice": "Continuer en vocal"
   },
   "progress": {
     "title": "Progrès",

--- a/messages/it.json
+++ b/messages/it.json
@@ -172,7 +172,7 @@
       "s8Body": "Questi termini possono essere aggiornati in qualsiasi momento. L'uso continuato del servizio dopo le modifiche costituisce l'accettazione dei termini rivisti.",
       "linkPrivacy": "Informativa sulla Privacy",
       "linkBack": "Torna alla registrazione",
-    "linkBackSettings": "Torna alle impostazioni"
+      "linkBackSettings": "Torna alle impostazioni"
     },
     "privacy": {
       "pageTitle": "Informativa sulla Privacy",
@@ -205,7 +205,7 @@
       "s7Body": "Per qualsiasi preoccupazione relativa alla privacy di questa istanza specifica, contatta l'amministratore del server che stai utilizzando. Per domande sul progetto FreeLingo, visita il repository del progetto su GitHub.",
       "linkTerms": "Termini di Servizio",
       "linkBack": "Torna alla registrazione",
-    "linkBackSettings": "Torna alle impostazioni"
+      "linkBackSettings": "Torna alle impostazioni"
     }
   },
   "dashboard": {
@@ -440,7 +440,8 @@
     "deleteTitle": "Elimina chat",
     "deleteMessage": "Questa conversazione verrà eliminata definitivamente.",
     "deleteConfirm": "Elimina",
-    "enterToSend": "Invio per inviare"
+    "enterToSend": "Invio per inviare",
+    "continueInVoice": "Continua in voce"
   },
   "progress": {
     "title": "Progressi",

--- a/messages/it.json
+++ b/messages/it.json
@@ -171,7 +171,8 @@
       "s8Title": "8. Modifiche ai Termini",
       "s8Body": "Questi termini possono essere aggiornati in qualsiasi momento. L'uso continuato del servizio dopo le modifiche costituisce l'accettazione dei termini rivisti.",
       "linkPrivacy": "Informativa sulla Privacy",
-      "linkBack": "Torna alla registrazione"
+      "linkBack": "Torna alla registrazione",
+    "linkBackSettings": "Torna alle impostazioni"
     },
     "privacy": {
       "pageTitle": "Informativa sulla Privacy",
@@ -203,7 +204,8 @@
       "s7Title": "7. Contatto",
       "s7Body": "Per qualsiasi preoccupazione relativa alla privacy di questa istanza specifica, contatta l'amministratore del server che stai utilizzando. Per domande sul progetto FreeLingo, visita il repository del progetto su GitHub.",
       "linkTerms": "Termini di Servizio",
-      "linkBack": "Torna alla registrazione"
+      "linkBack": "Torna alla registrazione",
+    "linkBackSettings": "Torna alle impostazioni"
     }
   },
   "dashboard": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -171,7 +171,8 @@
       "s8Title": "8. Alterações nestes Termos",
       "s8Body": "Estes termos podem ser atualizados a qualquer momento. O uso continuado do serviço após as alterações constitui aceitação dos termos revisados.",
       "linkPrivacy": "Política de Privacidade",
-      "linkBack": "Voltar ao cadastro"
+      "linkBack": "Voltar ao cadastro",
+    "linkBackSettings": "Voltar às configurações"
     },
     "privacy": {
       "pageTitle": "Política de Privacidade",
@@ -203,7 +204,8 @@
       "s7Title": "7. Contato",
       "s7Body": "Para qualquer preocupação relacionada à privacidade desta instância específica, entre em contato com o administrador do servidor que você está usando. Para perguntas sobre o projeto FreeLingo em si, visite o repositório do projeto no GitHub.",
       "linkTerms": "Termos de Serviço",
-      "linkBack": "Voltar ao cadastro"
+      "linkBack": "Voltar ao cadastro",
+    "linkBackSettings": "Voltar às configurações"
     }
   },
   "dashboard": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -172,7 +172,7 @@
       "s8Body": "Estes termos podem ser atualizados a qualquer momento. O uso continuado do serviço após as alterações constitui aceitação dos termos revisados.",
       "linkPrivacy": "Política de Privacidade",
       "linkBack": "Voltar ao cadastro",
-    "linkBackSettings": "Voltar às configurações"
+      "linkBackSettings": "Voltar às configurações"
     },
     "privacy": {
       "pageTitle": "Política de Privacidade",
@@ -205,7 +205,7 @@
       "s7Body": "Para qualquer preocupação relacionada à privacidade desta instância específica, entre em contato com o administrador do servidor que você está usando. Para perguntas sobre o projeto FreeLingo em si, visite o repositório do projeto no GitHub.",
       "linkTerms": "Termos de Serviço",
       "linkBack": "Voltar ao cadastro",
-    "linkBackSettings": "Voltar às configurações"
+      "linkBackSettings": "Voltar às configurações"
     }
   },
   "dashboard": {
@@ -440,7 +440,8 @@
     "deleteTitle": "Eliminar conversa",
     "deleteMessage": "Esta conversa será eliminada permanentemente.",
     "deleteConfirm": "Eliminar",
-    "enterToSend": "Enter para enviar"
+    "enterToSend": "Enter para enviar",
+    "continueInVoice": "Continuar por voz"
   },
   "progress": {
     "title": "Progresso",

--- a/specs/architecture.instructions.md
+++ b/specs/architecture.instructions.md
@@ -9,32 +9,53 @@ applyTo: "backend/**, frontend/**"
 
 ```
 freelingo/
-├── backend/                     # Python 3.12 FastAPI
+├── backend/                     # Python 3.14 FastAPI
 │   ├── app/
 │   │   ├── core/                # Config, DB engine, security, deps, rate limiter
-│   │   ├── models/              # SQLAlchemy 2.0 ORM models (9 models)
+│   │   ├── models/              # SQLAlchemy 2.0 ORM models (8 models)
 │   │   ├── schemas/             # Pydantic v2 request/response schemas
 │   │   ├── routers/             # 11 routers (10 REST + 1 WebSocket)
 │   │   ├── services/            # Business logic + external service clients (10 modules)
 │   │   └── data/
 │   │       └── en/              # Static curriculum and content data
 │   ├── alembic/
-│   │   └── versions/            # DB migrations (7)
+│   │   └── versions/            # DB migrations (9)
 │   └── tests/                   # pytest suite (10 test files)
 │
 ├── frontend/                    # Next.js 16 App Router
 │   ├── src/
 │   │   ├── app/
-│   │   │   ├── (auth)/          # Public routes (login, register, onboarding) — no sidebar
-│   │   │   ├── (app)/           # Authenticated routes — sidebar layout
-│   │   │   └── api/             # Next.js Route Handlers (SSE / binary proxies)
-│   │   ├── components/          # React components (shadcn/ui + custom)
-│   │   ├── data/                # Static data (curriculum, grammar, vocab, phrasebook, assessment-bank)
-│   │   ├── store/               # Zustand stores (auth, theme, progress, loading)
-│   │   ├── lib/                 # Utilities (apiFetch, WS builder, audio queue, target-languages)
+│   │   │   ├── (auth)/          # Public routes: login, register, onboarding — no sidebar
+│   │   │   ├── (app)/           # Authenticated routes (14 pages) — sidebar layout
+│   │   │   │   ├── admin/users/ # User management (admin only)
+│   │   │   │   ├── assessment/  # Level test entry + adaptive quiz
+│   │   │   │   ├── chat/        # AI tutor chat (SSE streaming, conversation history)
+│   │   │   │   ├── conversation/ # Real-time voice conversation (WebSocket + VAD)
+│   │   │   │   ├── dashboard/   # Home with XP, streak, plan summary
+│   │   │   │   ├── faq/
+│   │   │   │   ├── flashcards/
+│   │   │   │   ├── grammar/     # Grammar reference (index + [slug] detail)
+│   │   │   │   ├── lesson/[id]/ # Lesson player
+│   │   │   │   ├── phrasebook/
+│   │   │   │   ├── plan/        # Study plan + unit drawer
+│   │   │   │   ├── progress/    # Skills tracker
+│   │   │   │   ├── settings/    # Profile, avatar, conversation settings
+│   │   │   │   └── vocabulary/  # Vocabulary hub (index + [setId] detail)
+│   │   │   ├── (legal)/         # Terms and Privacy pages — minimal layout
+│   │   │   └── api/             # Next.js Route Handlers: chat (SSE), tts, stt proxies
+│   │   ├── components/
+│   │   │   ├── assessment/      # AdaptiveQuizCard, BeginnerGate, DurationSelector
+│   │   │   ├── conversation/    # ConversationMode, MicButton, StatusIndicator, TranscriptBubble, SessionTimeoutBanner
+│   │   │   ├── plan/            # LevelTestBanner, UnitCard, UnitDrawer
+│   │   │   ├── ui/              # shadcn/ui + custom: AudioPlayer, VoiceRecorder, confirm-dialog, loading-bar, …
+│   │   │   ├── TargetLanguageSelector.tsx
+│   │   │   └── ThemeProvider.tsx
+│   │   ├── data/                # Static content: curriculum, grammar, vocab, phrasebook, assessment-bank (+ en/ subfolder)
+│   │   ├── store/               # Zustand stores: auth, theme, progress, loading
+│   │   ├── lib/                 # Utilities: apiFetch, conversation-ws, audio, target-languages, utils
 │   │   ├── i18n/                # next-intl locale resolver
 │   │   └── middleware.ts        # Auth guard + locale detection
-│   ├── public/                  # Static assets (flags, VAD WASM models)
+│   ├── public/                  # Static assets (flags/, vad/ WASM models)
 │   └── scripts/                 # Postinstall helpers (copy-vad-models.js)
 │
 ├── messages/                    # i18n bundles (en, es, fr, pt, de, it)
@@ -488,7 +509,7 @@ Barge-in: user speaks again → cancel current generation
 
 ## Code standards
 
-### Backend (Python 3.12)
+### Backend (Python 3.14)
 
 | Tool | Purpose |
 |------|---------|

--- a/specs/docker.instructions.md
+++ b/specs/docker.instructions.md
@@ -11,7 +11,7 @@ applyTo: "docker-compose.yml, .env*, **/Dockerfile"
 |---------|-------|-------|-------|-------|
 | `postgres` | `postgres:16-alpine` | 5432 (internal) | 1 | Health check via `pg_isready` |
 | `redis` | `redis:7-alpine` | 6379 (internal) | 1 | Password-protected, health check via `redis-cli ping` |
-| `backend` | Built from `backend/Dockerfile` | 8000 | 1 | Python 3.12, Uvicorn, depends on postgres+redis |
+| `backend` | Built from `backend/Dockerfile` | 8000 | 1 | Python 3.14, Uvicorn, depends on postgres+redis |
 | `frontend` | Built from `frontend/Dockerfile` | 3000 | 1 | Next.js 16, built with `NEXT_PUBLIC_API_URL` as build arg |
 | `kokoro` | `ghcr.io/remsky/kokoro-fastapi-gpu:latest` | 8880 | 2 | TTS, GPU via NVIDIA deploy block |
 | `whisper` | `onerahmet/openai-whisper-asr-webservice:latest-gpu` | 9000 | 2 | STT, GPU via NVIDIA deploy block |
@@ -40,7 +40,7 @@ The compose file defines 6 services (plus optional Ollama) and 2 named volumes (
 
 ### Backend
 
-- Built from `backend/Dockerfile` (Python 3.12 slim)
+- Built from `backend/Dockerfile` (Python 3.14 slim)
 - Receives all configuration via environment variables (passed from `.env`)
 - Binds `./backend:/app` volume for live development
 - Startup command: `uvicorn app.main:app --host 0.0.0.0 --port 8000`

--- a/specs/phase-1-platform.instructions.md
+++ b/specs/phase-1-platform.instructions.md
@@ -29,7 +29,7 @@ A complete platform that evaluates the user's English CEFR level through a 3-ste
 
 ### Backend stack
 
-- **Python 3.12** with FastAPI, Uvicorn
+- **Python 3.14** with FastAPI, Uvicorn
 - **asyncpg** driver for async PostgreSQL access
 - **SQLAlchemy 2.0** async ORM with `Mapped[T]` declarative style
 - **Alembic** for async DB migrations (autogenerate from models)

--- a/specs/readme.instructions.md
+++ b/specs/readme.instructions.md
@@ -43,7 +43,7 @@ Current badges shown in README:
 ```markdown
 ![License](https://img.shields.io/badge/license-AGPL%20v3-blue?style=flat-square)
 ![Next.js](https://img.shields.io/badge/next.js-16-black?style=flat-square)
-![Python](https://img.shields.io/badge/python-3.12-blue?style=flat-square)
+![Python](https://img.shields.io/badge/python-3.14-blue?style=flat-square)
 ![Self-hosted](https://img.shields.io/badge/self--hosted-yes-orange?style=flat-square)
 ```
 
@@ -58,7 +58,7 @@ Keep it short. One paragraph max. Delegate detail to the architecture spec:
 ```markdown
 ## Architecture
 
-Monorepo: `backend/` (Python 3.12 FastAPI) + `frontend/` (Next.js 16 App Router)
+Monorepo: `backend/` (Python 3.14 FastAPI) + `frontend/` (Next.js 16 App Router)
 deployed via Docker Compose with PostgreSQL 16 and Redis 7.
 The backend proxies all external services (Ollama, Kokoro, Whisper) —
 the frontend never calls them directly.
@@ -72,7 +72,7 @@ Top-level layout only — directories only, no individual files:
 
 ```
 freelingo/
-├── backend/            # FastAPI (Python 3.12)
+├── backend/            # FastAPI (Python 3.14)
 ├── frontend/           # Next.js 16 (React 19)
 ├── specs/              # Architecture and feature specifications
 ├── messages/            # i18n message bundles (en, es, fr, pt, de, it)
@@ -92,7 +92,7 @@ freelingo/
 ```markdown
 | Layer | Technology |
 |-------|------------|
-| Backend | Python 3.12, FastAPI, SQLAlchemy 2.0 (async), Alembic |
+| Backend | Python 3.14, FastAPI, SQLAlchemy 2.0 (async), Alembic |
 | Database | PostgreSQL 16 |
 | Cache | Redis 7 |
 | LLM | Ollama (local), OpenAI, Anthropic, DeepSeek |

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.3.2**
+**1.3.3**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request delivers version 1.3.3, introducing a seamless transition from text to voice in the AI tutor chat, along with Python 3.14 upgrade and improved context handling between chat and voice sessions. Users can now continue their tutoring session in voice mode, preserving recent chat history for more natural conversations. The backend and frontend have been updated to support this flow, and comprehensive tests have been added for the new context logic. The update also bumps the Python version to 3.14 across the stack and refines some UI elements.

**Major new feature: Seamless "Continue in voice" transition**

* Added a "Continue in voice" button to the chat header, visible when a conversation is idle and has messages. Clicking it serializes up to the last 20 non-empty messages into `sessionStorage` and navigates to the real-time voice conversation page. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R19) [[2]](diffhunk://#diff-36785259041e3f350d8b3e8c9ed96b91bffe889d68b78b36e6aad5096478a8a7R102-R109) [[3]](diffhunk://#diff-36785259041e3f350d8b3e8c9ed96b91bffe889d68b78b36e6aad5096478a8a7L247-R266)
* The voice conversation page reads and clears the `voice_context` key from `sessionStorage` on mount, passing it as `initialContext` to the `ConversationMode` component.
* `ConversationMode` now accepts an optional `initialContext` prop and includes it in the WebSocket authentication handshake if present.
* The backend WebSocket endpoint extracts and sanitizes the optional `context` field from the auth message (max 20 entries, valid roles, non-empty content) and passes it to `ConversationPipeline`, which pre-populates its history with up to the last 10 valid turns for seamless context continuation. [[1]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R29-R33) [[2]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307L76-R93) [[3]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R105) [[4]](diffhunk://#diff-a74cc90ba3ba21401e80b96a69172fec6d9dc592ed1b1ca142b455251033c9d0R57) [[5]](diffhunk://#diff-a74cc90ba3ba21401e80b96a69172fec6d9dc592ed1b1ca142b455251033c9d0L71-R83)

**Testing and validation**

* Added 8 new unit tests for `ConversationPipeline.initial_context`, covering empty/None input, valid population, truncation to 10, invalid-role filtering, empty-content filtering, non-dict entry filtering, and extra-key stripping.

**Python version upgrade**

* Upgraded Python version from 3.11/3.12 to 3.14 in Dockerfile, CI workflow, documentation, and tooling configuration to standardize the stack. [[1]](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486L1-R1) [[2]](diffhunk://#diff-56dd363bcda971c4768fd7ac8876812a3ac4ba6f090efb2395214f31536ea805L31-R31) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L9-R9) [[5]](diffhunk://#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551L2-R2) [[6]](diffhunk://#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551L20-R20)

**User interface and i18n**

* Added the `chat.continueInVoice` i18n key to all 6 locale files for the new button.
* Updated version display to 1.3.3 in the app layout. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L225-R225) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L344-R344)
* Simplified links to Terms and Privacy in settings and registration pages (now open in the same tab and include a `from` query parameter). [[1]](diffhunk://#diff-280ffd3e3fb6a926b248de1137f70724a559f24af502f22bc2fdcbd68f2354a0L457-L471) [[2]](diffhunk://#diff-8635d23b595c2977887ee24801c4422a88d43f85fd138765e4dcb5ec1bbaac92L146-R148)

**Documentation**

* Updated `CHANGELOG.md` for v1.3.3 and revised architecture documentation to reflect Python 3.14 usage. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R19) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L9-R9)

These changes significantly improve the user experience by enabling smooth transitions between chat and voice tutoring, while also modernizing the codebase and enhancing test coverage.