### PR TITLE
feature: quota

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,7 @@ TTS_BASE_URL=http://kokoro:8880
 TTS_VOICE=af_heart
 OPENAI_TTS_MODEL=tts-1
 OPENAI_TTS_VOICE=nova
+OPENAI_TTS_SPEED=1.0
 
 # STT — set STT_PROVIDER=local (faster-whisper) or openai
 # Local: requires the whisper service running in docker-compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.8] - 2026-05-09
+
+### Fixed
+- Conversation quota: daily minutes now checked before incrementing the weekly session counter, preventing a wasted session slot when the daily limit is already exhausted
+
 ## [1.3.7] - 2026-05-09
 
 ### Changed

--- a/backend/alembic/versions/0011_quota_fields.py
+++ b/backend/alembic/versions/0011_quota_fields.py
@@ -1,0 +1,41 @@
+"""Add conversation quota fields to users
+
+Revision ID: 0011_quota_fields
+Revises: 0010_llm_usage
+Create Date: 2026-05-09
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011_quota_fields"
+down_revision: Union[str, None] = "0010_llm_usage"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "conversation_weekly_sessions",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "conversation_daily_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "conversation_daily_minutes")
+    op.drop_column("users", "conversation_weekly_sessions")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     TTS_VOICE: str = "af_heart"
     OPENAI_TTS_MODEL: str = "tts-1"
     OPENAI_TTS_VOICE: str = "nova"
+    OPENAI_TTS_SPEED: float = 1.0
     STT_PROVIDER: str = "local"  # local | openai
     STT_BASE_URL: str = "http://whisper:9000"
     OPENAI_STT_MODEL: str = "whisper-1"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,6 +39,7 @@ async def lifespan(app: FastAPI):  # noqa: ANN201
             api_key=settings.OPENAI_API_KEY,
             model=settings.OPENAI_TTS_MODEL,
             voice=settings.OPENAI_TTS_VOICE,
+            speed=settings.OPENAI_TTS_SPEED,
         )
     else:
         app.state.tts_service = KokoroTTSService(settings.TTS_BASE_URL, settings.TTS_VOICE)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -27,6 +27,12 @@ class User(Base):
     conversation_inactivity_timeout: Mapped[int] = mapped_column(
         Integer, nullable=False, default=180    # 180=3min, options: 60|180|300
     )
+    conversation_weekly_sessions: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0     # 0 = unlimited
+    )
+    conversation_daily_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0     # 0 = unlimited
+    )
     avatar: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None)

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -192,10 +192,34 @@ async def update_user(
         user.role = data.role
     if data.is_active is not None:
         user.is_active = data.is_active
+    if data.conversation_weekly_sessions is not None:
+        user.conversation_weekly_sessions = data.conversation_weekly_sessions
+    if data.conversation_daily_minutes is not None:
+        user.conversation_daily_minutes = data.conversation_daily_minutes
 
     await db.commit()
     await db.refresh(user)
     return user
+
+
+@router.get("/users/{user_id}/quota")
+async def get_user_quota(
+    user_id: int,
+    admin: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+    redis: Redis = Depends(get_redis),
+):
+    """Return live quota status (Redis) for a user."""
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    from app.services.quota_service import get_quota_status  # noqa: PLC0415
+    return await get_quota_status(
+        redis,
+        user_id,
+        user.conversation_weekly_sessions,
+        user.conversation_daily_minutes,
+    )
 
 
 @router.delete("/users/{user_id}")

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -295,3 +295,18 @@ async def delete_me(
     response.delete_cookie("refresh_token")
     await db.delete(current_user)
     await db.commit()
+
+
+@router.get("/quota")
+async def get_my_quota(
+    current_user: User = Depends(get_current_user),
+    redis: Redis = Depends(get_redis),
+):
+    """Return conversation quota status for the current user."""
+    from app.services.quota_service import get_quota_status  # noqa: PLC0415
+    return await get_quota_status(
+        redis,
+        current_user.id,
+        current_user.conversation_weekly_sessions,
+        current_user.conversation_daily_minutes,
+    )

--- a/backend/app/routers/conversation.py
+++ b/backend/app/routers/conversation.py
@@ -4,17 +4,20 @@ import asyncio
 import logging
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from redis.asyncio import Redis
 
 logger = logging.getLogger(__name__)
 from jwt.exceptions import PyJWTError
 from sqlalchemy import select
 
+from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.core.security import decode_access_token
 from app.models.study_plan import StudyPlan
 from app.models.user import User
 from app.services.conversation_pipeline import ConversationPipeline
 from app.services.llm_adapter import llm_adapter
+from app.services.quota_service import check_and_increment_sessions, check_daily_minutes
 
 router = APIRouter(tags=["conversation"])
 
@@ -74,6 +77,8 @@ async def conversation_ws(
         inactivity_timeout = user.conversation_inactivity_timeout
         native_language = user.native_language
         target_language = user.target_language
+        weekly_sessions_limit = user.conversation_weekly_sessions
+        daily_minutes_limit = user.conversation_daily_minutes
 
     # Validate and sanitize optional chat context passed from the tutor chat
     valid_context: list[dict] | None = None
@@ -93,6 +98,54 @@ async def conversation_ws(
                 user_id, cefr_level, max_duration, inactivity_timeout, len(valid_context) if valid_context else 0)
     # (already accepted at the top)
 
+    # --- Quota checks ---
+    redis = Redis.from_url(settings.REDIS_URL, decode_responses=True)
+    try:
+        # Check daily minutes first (read-only) so we never waste a weekly session slot
+        daily_ok, minutes_used, minutes_limit = await check_daily_minutes(
+            redis, user_id, daily_minutes_limit
+        )
+        if not daily_ok:
+            logger.info(
+                "[conversation] Daily minutes quota exceeded — user=%s used=%s limit=%s",
+                user_id, minutes_used, minutes_limit,
+            )
+            await websocket.send_json({
+                "type": "error",
+                "code": "quota_exceeded_time",
+                "message": f"Daily time limit reached ({minutes_used}/{minutes_limit} min).",
+            })
+            await websocket.close(code=1008)
+            await redis.aclose()
+            return
+
+        # Then check + increment weekly sessions
+        sessions_ok, sessions_used, sessions_limit = await check_and_increment_sessions(
+            redis, user_id, weekly_sessions_limit
+        )
+        if not sessions_ok:
+            logger.info(
+                "[conversation] Weekly session quota exceeded — user=%s used=%s limit=%s",
+                user_id, sessions_used, sessions_limit,
+            )
+            await websocket.send_json({
+                "type": "error",
+                "code": "quota_exceeded_sessions",
+                "message": f"Weekly session limit reached ({sessions_used}/{sessions_limit}).",
+            })
+            await websocket.close(code=1008)
+            await redis.aclose()
+            return
+
+        # Cap session max_duration to remaining daily minutes if limited
+        if daily_minutes_limit > 0:
+            remaining_seconds = (daily_minutes_limit - minutes_used) * 60
+            max_duration = min(max_duration, remaining_seconds)
+    except Exception as exc:
+        logger.error("[conversation] Quota check failed: %s", exc)
+        await redis.aclose()
+        raise
+
     pipeline = ConversationPipeline(
         llm=llm_adapter,
         tts=tts_service,
@@ -105,14 +158,15 @@ async def conversation_ws(
         initial_context=valid_context,
         user_id=user_id,
     )
+    pipeline._redis = redis
 
     try:
         await pipeline.run(websocket)
     except WebSocketDisconnect:
         logger.info("[conversation] WebSocketDisconnect — user=%s", user_id)
-        await pipeline.cleanup()
     except asyncio.CancelledError:
         logger.info("[conversation] CancelledError — user=%s", user_id)
-        await pipeline.cleanup()
     finally:
+        await pipeline.cleanup()
+        await redis.aclose()
         logger.info("[conversation] Session ended — user=%s", user_id)

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -30,6 +30,8 @@ class AdminUserUpdate(BaseModel):
     display_name: Optional[str] = Field(default=None, max_length=100)
     role: Optional[Literal["user", "admin"]] = None
     is_active: Optional[bool] = None
+    conversation_weekly_sessions: Optional[int] = Field(default=None, ge=0)
+    conversation_daily_minutes: Optional[int] = Field(default=None, ge=0)
 
 
 class AdminUserResponse(BaseModel):
@@ -40,6 +42,8 @@ class AdminUserResponse(BaseModel):
     role: str
     native_language: str
     is_active: bool
+    conversation_weekly_sessions: int = 0
+    conversation_daily_minutes: int = 0
     created_at: datetime
     last_login: Optional[datetime]
 

--- a/backend/app/services/conversation_pipeline.py
+++ b/backend/app/services/conversation_pipeline.py
@@ -156,10 +156,13 @@ class ConversationPipeline:
                 if SENTENCE_END.search(sentence_buffer.strip()) or len(sentence_buffer) > MAX_BUFFER_CHARS:
                     sentence = sentence_buffer.strip()
                     sentence_buffer = ""
+                    # Send accumulated text before audio so transcript updates in sync
+                    await ws.send_json({"type": "transcript", "role": "assistant", "text": full_response.strip(), "final": False})
                     await self._synthesize_and_send(sentence, ws)
 
             # Flush remaining buffer
             if sentence_buffer.strip():
+                await ws.send_json({"type": "transcript", "role": "assistant", "text": full_response.strip(), "final": False})
                 await self._synthesize_and_send(sentence_buffer.strip(), ws)
 
             # Persist token usage best-effort (never blocks the response)

--- a/backend/app/services/conversation_pipeline.py
+++ b/backend/app/services/conversation_pipeline.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from app.services.language_helpers import get_english_variant, get_iso639
 from app.services.llm_adapter import LLMError, LLMStream, LLMTimeoutError, LLMUnavailableError
+from app.services.quota_service import record_session_seconds
 
 if TYPE_CHECKING:
     from fastapi import WebSocket
@@ -69,6 +70,8 @@ class ConversationPipeline:
         )
         self.max_duration = max_duration
         self.inactivity_timeout = inactivity_timeout
+        self._redis: object | None = None  # injected after construction
+        self._recorded = False
 
         self.current_task: asyncio.Task | None = None
         # Pre-populate history from optional chat context
@@ -235,6 +238,15 @@ class ConversationPipeline:
             self.history.pop()
 
     async def cleanup(self) -> None:
+        # Record actual session duration once, best-effort
+        if not self._recorded:
+            self._recorded = True
+            elapsed = int(time.monotonic() - self._session_start)
+            if self._redis is not None and self._user_id is not None and elapsed > 0:
+                try:
+                    await record_session_seconds(self._redis, self._user_id, elapsed)
+                except Exception:
+                    logger.debug("[pipeline] Failed to record session seconds — ignored")
         await self.cancel_current()
         for t in self._timer_tasks:
             t.cancel()

--- a/backend/app/services/quota_service.py
+++ b/backend/app/services/quota_service.py
@@ -1,0 +1,118 @@
+"""Conversation quota helpers backed by Redis.
+
+Two independent counters per user:
+  - Weekly sessions: conv_sessions:{user_id}:{YYYY-Www}  (resets each Monday)
+  - Daily minutes:   conv_seconds:{user_id}:{YYYY-MM-DD} (resets each midnight UTC)
+
+A limit of 0 means unlimited.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+# ── Key helpers ──────────────────────────────────────────────────────────────
+
+def _week_key(user_id: int) -> str:
+    now = datetime.now(timezone.utc)
+    year, week, _ = now.isocalendar()
+    return f"conv_sessions:{user_id}:{year}-W{week:02d}"
+
+
+def _day_key(user_id: int) -> str:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return f"conv_seconds:{user_id}:{today}"
+
+
+def _seconds_until_monday() -> int:
+    now = datetime.now(timezone.utc)
+    days_ahead = 7 - now.weekday()          # weekday: 0=Mon … 6=Sun
+    next_monday = (now + timedelta(days=days_ahead)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    return max(int((next_monday - now).total_seconds()), 1)
+
+
+def _seconds_until_midnight() -> int:
+    now = datetime.now(timezone.utc)
+    tomorrow = (now + timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    return max(int((tomorrow - now).total_seconds()), 1)
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+async def get_quota_status(
+    redis: object,
+    user_id: int,
+    weekly_limit: int,
+    daily_minutes_limit: int,
+) -> dict:
+    """Return current usage without modifying any counter."""
+    sessions_used = int(await redis.get(_week_key(user_id)) or 0)  # type: ignore[attr-defined]
+    seconds_used = int(await redis.get(_day_key(user_id)) or 0)  # type: ignore[attr-defined]
+    minutes_used = seconds_used // 60
+
+    return {
+        "sessions_this_week": sessions_used,
+        "sessions_limit": weekly_limit,
+        "sessions_unlimited": weekly_limit == 0,
+        "minutes_today": minutes_used,
+        "minutes_limit": daily_minutes_limit,
+        "time_unlimited": daily_minutes_limit == 0,
+    }
+
+
+async def check_and_increment_sessions(
+    redis: object,
+    user_id: int,
+    weekly_limit: int,
+) -> tuple[bool, int, int]:
+    """Check weekly session quota and increment if allowed.
+
+    Returns (allowed, sessions_used_before, limit).
+    When limit == 0, always returns (True, current, 0).
+    """
+    week_key = _week_key(user_id)
+    current = int(await redis.get(week_key) or 0)  # type: ignore[attr-defined]
+
+    if weekly_limit > 0 and current >= weekly_limit:
+        return False, current, weekly_limit
+
+    new_val = await redis.incr(week_key)  # type: ignore[attr-defined]
+    if new_val == 1:
+        # First session of the week — set TTL
+        await redis.expire(week_key, _seconds_until_monday())  # type: ignore[attr-defined]
+
+    return True, current, weekly_limit
+
+
+async def check_daily_minutes(
+    redis: object,
+    user_id: int,
+    daily_minutes_limit: int,
+) -> tuple[bool, int, int]:
+    """Check whether the user has daily minutes remaining.
+
+    Returns (allowed, minutes_used, limit).
+    When limit == 0, always returns (True, current_minutes, 0).
+    """
+    seconds_used = int(await redis.get(_day_key(user_id)) or 0)  # type: ignore[attr-defined]
+    minutes_used = seconds_used // 60
+
+    if daily_minutes_limit == 0:
+        return True, minutes_used, 0
+
+    return minutes_used < daily_minutes_limit, minutes_used, daily_minutes_limit
+
+
+async def record_session_seconds(redis: object, user_id: int, seconds: int) -> None:
+    """Accumulate seconds used today. Safe to call multiple times (idempotent TTL)."""
+    if seconds <= 0:
+        return
+    day_key = _day_key(user_id)
+    await redis.incrby(day_key, seconds)  # type: ignore[attr-defined]
+    ttl = await redis.ttl(day_key)  # type: ignore[attr-defined]
+    if ttl < 0:
+        await redis.expire(day_key, _seconds_until_midnight())  # type: ignore[attr-defined]

--- a/backend/app/services/tts_service.py
+++ b/backend/app/services/tts_service.py
@@ -25,10 +25,11 @@ class KokoroTTSService:
 
 
 class OpenAITTSService:
-    def __init__(self, api_key: str, model: str, voice: str) -> None:
+    def __init__(self, api_key: str, model: str, voice: str, speed: float = 1.0) -> None:
         self._client = openai.AsyncOpenAI(api_key=api_key)
         self.model = model
         self.voice = voice
+        self.speed = speed
 
     async def synthesize(self, text: str, voice: str | None = None) -> bytes:
         """Call OpenAI TTS API and return MP3 audio bytes."""
@@ -37,5 +38,6 @@ class OpenAITTSService:
             voice=voice or self.voice,
             input=text,
             response_format="mp3",
+            speed=self.speed,
         )
         return response.content

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       TTS_VOICE: ${TTS_VOICE:-af_heart}
       OPENAI_TTS_MODEL: ${OPENAI_TTS_MODEL:-tts-1}
       OPENAI_TTS_VOICE: ${OPENAI_TTS_VOICE:-nova}
+      OPENAI_TTS_SPEED: ${OPENAI_TTS_SPEED:-1.0}
       STT_PROVIDER: ${STT_PROVIDER:-local}
       STT_BASE_URL: ${STT_BASE_URL:-http://whisper:9000}
       OPENAI_STT_MODEL: ${OPENAI_STT_MODEL:-whisper-1}

--- a/frontend/src/app/(app)/admin/users/[id]/page.tsx
+++ b/frontend/src/app/(app)/admin/users/[id]/page.tsx
@@ -32,6 +32,17 @@ interface AdminUser {
   role: string
   native_language: string
   is_active: boolean
+  conversation_weekly_sessions: number
+  conversation_daily_minutes: number
+}
+
+interface QuotaStatus {
+  sessions_this_week: number
+  sessions_limit: number
+  sessions_unlimited: boolean
+  minutes_today: number
+  minutes_limit: number
+  time_unlimited: boolean
 }
 
 function StatRow({ label, value }: { label: string; value: React.ReactNode }) {
@@ -63,6 +74,11 @@ export default function AdminUserStatsPage() {
 
   const [user, setUser] = useState<AdminUser | null>(null)
   const [stats, setStats] = useState<UserStats | null>(null)
+  const [quota, setQuota] = useState<QuotaStatus | null>(null)
+  const [quotaWeekly, setQuotaWeekly] = useState<string>('')
+  const [quotaDaily, setQuotaDaily] = useState<string>('')
+  const [quotaSaving, setQuotaSaving] = useState(false)
+  const [quotaSaved, setQuotaSaved] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -72,8 +88,9 @@ export default function AdminUserStatsPage() {
     Promise.all([
       apiFetch(`/api/admin/users/${userId}`),
       apiFetch(`/api/admin/users/${userId}/stats`),
+      apiFetch(`/api/admin/users/${userId}/quota`),
     ])
-      .then(async ([uRes, sRes]) => {
+      .then(async ([uRes, sRes, qRes]) => {
         if (!uRes.ok || !sRes.ok) {
           setError('loadError')
           return
@@ -81,10 +98,48 @@ export default function AdminUserStatsPage() {
         const [uData, sData] = await Promise.all([uRes.json(), sRes.json()])
         setUser(uData)
         setStats(sData)
+        setQuotaWeekly(String(uData.conversation_weekly_sessions))
+        setQuotaDaily(String(uData.conversation_daily_minutes))
+        if (qRes.ok) {
+          const qData: QuotaStatus = await qRes.json()
+          setQuota(qData)
+        }
       })
       .catch(() => setError('loadError'))
       .finally(() => setLoading(false))
   }, [userId])
+
+  async function saveQuota() {
+    if (!userId) return
+    setQuotaSaving(true)
+    setQuotaSaved(false)
+    const weekly = parseInt(quotaWeekly, 10)
+    const daily = parseInt(quotaDaily, 10)
+    if (isNaN(weekly) || weekly < 0 || isNaN(daily) || daily < 0) {
+      setQuotaSaving(false)
+      return
+    }
+    try {
+      const res = await apiFetch(`/api/admin/users/${userId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          conversation_weekly_sessions: weekly,
+          conversation_daily_minutes: daily,
+        }),
+      })
+      if (res.ok) {
+        const updated: AdminUser = await res.json()
+        setUser(updated)
+        setQuotaWeekly(String(updated.conversation_weekly_sessions))
+        setQuotaDaily(String(updated.conversation_daily_minutes))
+        setQuotaSaved(true)
+        setTimeout(() => setQuotaSaved(false), 3000)
+      }
+    } finally {
+      setQuotaSaving(false)
+    }
+  }
 
   if (loading) {
     return (
@@ -222,6 +277,56 @@ export default function AdminUserStatsPage() {
             />
           </>
         )}
+      </Section>
+
+      {/* Conversation Quotas */}
+      <Section title={t('sectionQuota')}>
+        {quota && (
+          <>
+            <StatRow
+              label={t('quotaUsedSessions')}
+              value={quota.sessions_unlimited ? t('quotaUnlimitedLabel') : `${quota.sessions_this_week} / ${quota.sessions_limit}`}
+            />
+            <StatRow
+              label={t('quotaUsedMinutes')}
+              value={quota.time_unlimited ? t('quotaUnlimitedLabel') : `${quota.minutes_today} / ${quota.minutes_limit} min`}
+            />
+          </>
+        )}
+        <div className="py-3 space-y-3">
+          <div className="flex items-center justify-between gap-4">
+            <label className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase shrink-0">
+              {t('quotaWeeklySessions')}
+            </label>
+            <input
+              type="number"
+              min={0}
+              value={quotaWeekly}
+              onChange={(e) => setQuotaWeekly(e.target.value)}
+              className="w-24 bg-fl-bg border border-fl-border px-3 py-1.5 font-mono text-sm text-fl-fg text-right focus:outline-none focus:border-fl-accent"
+            />
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <label className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase shrink-0">
+              {t('quotaDailyMinutes')}
+            </label>
+            <input
+              type="number"
+              min={0}
+              value={quotaDaily}
+              onChange={(e) => setQuotaDaily(e.target.value)}
+              className="w-24 bg-fl-bg border border-fl-border px-3 py-1.5 font-mono text-sm text-fl-fg text-right focus:outline-none focus:border-fl-accent"
+            />
+          </div>
+          <p className="font-mono text-fl-hint text-fl-muted-4">{t('quotaUnlimitedLabel')}</p>
+          <button
+            onClick={saveQuota}
+            disabled={quotaSaving}
+            className="w-full border border-fl-border bg-fl-surface px-4 py-2 font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase hover:text-fl-fg hover:border-fl-fg transition-colors disabled:opacity-40"
+          >
+            {quotaSaved ? `✓ ${t('quotaSaved')}` : t('quotaSave')}
+          </button>
+        </div>
       </Section>
     </div>
   )

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -342,7 +342,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.7</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.8</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/components/conversation/ConversationMode.tsx
+++ b/frontend/src/components/conversation/ConversationMode.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { useMicVAD } from '@ricky0123/vad-react'
 import { useTranslations } from 'next-intl'
 import { useAuthStore } from '@/store/auth'
+import { apiFetch } from '@/lib/api'
 import { float32ToWav, createAudioQueue, type AudioQueue } from '@/lib/audio'
 import { buildConversationWsUrl, type WsMessage, type ChatContextItem } from '@/lib/conversation-ws'
 import StatusIndicator, { type ConvStatus } from './StatusIndicator'
@@ -15,6 +16,40 @@ interface TranscriptEntry {
   id: number
   role: 'user' | 'assistant'
   text: string
+}
+
+interface QuotaStatus {
+  sessions_this_week: number
+  sessions_limit: number
+  sessions_unlimited: boolean
+  minutes_today: number
+  minutes_limit: number
+  time_unlimited: boolean
+}
+
+function QuotaBar({ label, used, limit, unlimited }: { label: string; used: number; limit: number; unlimited: boolean }) {
+  const pct = unlimited || limit === 0 ? null : Math.min(100, Math.round((used / limit) * 100))
+  const exceeded = !unlimited && limit > 0 && used >= limit
+  return (
+    <div className="flex items-center gap-3">
+      <span className="font-mono text-fl-hint tracking-widest text-fl-muted-4 uppercase w-36 shrink-0">{label}</span>
+      {unlimited ? (
+        <span className="font-mono text-fl-hint text-fl-muted-2">∞</span>
+      ) : (
+        <>
+          <div className="flex-1 h-1 bg-fl-surface-2 overflow-hidden">
+            <div
+              className={`h-full transition-all ${exceeded ? 'bg-fl-error' : 'bg-fl-accent'}`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <span className={`font-mono text-fl-hint tabular-nums ${exceeded ? 'text-fl-error' : 'text-fl-muted-2'}`}>
+            {used}&thinsp;/&thinsp;{limit}
+          </span>
+        </>
+      )}
+    </div>
+  )
 }
 
 export default function ConversationMode({ initialContext }: { initialContext?: ChatContextItem[] }) {
@@ -31,6 +66,17 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [userSpeaking, setUserSpeaking] = useState(false)
   const [assistantSpeaking, setAssistantSpeaking] = useState(false)
+  const [quota, setQuota] = useState<QuotaStatus | null>(null)
+
+  // ─── Fetch quota on mount ─────────────────────────────────────────────────
+  const refreshQuota = useCallback(() => {
+    apiFetch('/api/auth/quota')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: QuotaStatus | null) => data && setQuota(data))
+      .catch(() => { })
+  }, [])
+
+  useEffect(() => { refreshQuota() }, [refreshQuota])
 
   // ─── Refs ─────────────────────────────────────────────────────────────────
   const wsRef = useRef<WebSocket | null>(null)
@@ -164,7 +210,11 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
               setErrorMsg(
                 msg.code === 'services_disabled'
                   ? t('errorServicesDisabled')
-                  : (msg.message ?? t('errorConnection')),
+                  : msg.code === 'quota_exceeded_sessions'
+                    ? t('quotaExceededSessions')
+                    : msg.code === 'quota_exceeded_time'
+                      ? t('quotaExceededTime')
+                      : (msg.message ?? t('errorConnection')),
               )
               setStatus('error')
               ws.close()
@@ -218,6 +268,7 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
     setErrorMsg(null)
     setUserSpeaking(false)
     setAssistantSpeaking(false)
+    refreshQuota()
 
     // Start mic (requests permission if not already granted)
     vad.start().catch((e: unknown) => {
@@ -240,6 +291,8 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
     audioQueueRef.current = null
     setSessionActive(false)
     setStatus('ended')
+    // Allow a moment for the backend to record session seconds, then refresh
+    setTimeout(() => refreshQuota(), 1500)
   }
 
   // Cleanup on unmount
@@ -307,6 +360,23 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
 
       {/* Controls */}
       <div className="flex flex-col items-center gap-4 pb-2">
+        {/* Quota widget */}
+        {quota && (
+          <div className="w-full space-y-1.5 border border-fl-border bg-fl-surface px-4 py-3">
+            <QuotaBar
+              label={t('quotaSessions')}
+              used={quota.sessions_this_week}
+              limit={quota.sessions_limit}
+              unlimited={quota.sessions_unlimited}
+            />
+            <QuotaBar
+              label={t('quotaMinutes')}
+              used={quota.minutes_today}
+              limit={quota.minutes_limit}
+              unlimited={quota.time_unlimited}
+            />
+          </div>
+        )}
         <StatusIndicator
           status={status}
           userSpeaking={userSpeaking}

--- a/frontend/src/components/conversation/ConversationMode.tsx
+++ b/frontend/src/components/conversation/ConversationMode.tsx
@@ -20,6 +20,7 @@ interface TranscriptEntry {
 export default function ConversationMode({ initialContext }: { initialContext?: ChatContextItem[] }) {
   const t = useTranslations('conversation')
   const accessToken = useAuthStore((s) => s.accessToken)
+  const user = useAuthStore((s) => s.user)
 
   // ─── UI State ────────────────────────────────────────────────────────────
   const [status, setStatus] = useState<ConvStatus>('loading')
@@ -272,10 +273,22 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
           </p>
         )}
         {transcript.map((entry) => (
-          <TranscriptBubble key={entry.id} role={entry.role} text={entry.text} />
+          <TranscriptBubble
+            key={entry.id}
+            role={entry.role}
+            text={entry.text}
+            userAvatar={user?.avatar}
+            userInitial={(user?.displayName || user?.username || '?')[0]}
+          />
         ))}
         {streamingText !== null && (
-          <TranscriptBubble role="assistant" text={streamingText} streaming />
+          <TranscriptBubble
+            role="assistant"
+            text={streamingText}
+            streaming
+            userAvatar={user?.avatar}
+            userInitial={(user?.displayName || user?.username || '?')[0]}
+          />
         )}
         <div ref={transcriptEndRef} />
       </div>

--- a/frontend/src/components/conversation/TranscriptBubble.tsx
+++ b/frontend/src/components/conversation/TranscriptBubble.tsx
@@ -1,27 +1,44 @@
+import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 
 interface Props {
   role: 'user' | 'assistant'
   text: string
   streaming?: boolean
+  userAvatar?: string | null
+  userInitial?: string
 }
 
-export default function TranscriptBubble({ role, text, streaming = false }: Props) {
+export default function TranscriptBubble({ role, text, streaming = false, userAvatar, userInitial }: Props) {
   const t = useTranslations('conversation')
   const isUser = role === 'user'
 
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
-      <div className={`max-w-[80%] ${isUser ? 'items-end' : 'items-start'} flex flex-col gap-1`}>
+    <div className={`flex items-end gap-2 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+      {/* Avatar */}
+      <div className="flex-shrink-0 w-7 h-7 rounded-full overflow-hidden border border-fl-border mb-0.5">
+        {!isUser ? (
+          <Image src="/logo.png" alt="Tutor" width={28} height={28} className="w-full h-full object-cover" />
+        ) : userAvatar ? (
+          <Image src={userAvatar} alt="" width={28} height={28} className="w-full h-full object-cover" unoptimized />
+        ) : (
+          <div className="w-full h-full bg-fl-surface-2 flex items-center justify-center">
+            <span className="font-mono text-fl-hint text-fl-muted-1 select-none">
+              {(userInitial ?? '?').toUpperCase()}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className={`max-w-[75%] flex flex-col gap-1 ${isUser ? 'items-end' : 'items-start'}`}>
         <span className="font-mono text-fl-label tracking-widest text-fl-muted-4 uppercase">
           {isUser ? t('you') : t('assistant')}
         </span>
         <div
-          className={`px-4 py-3 font-mono text-sm leading-relaxed border ${
-            isUser
+          className={`px-4 py-3 font-mono text-sm leading-relaxed border ${isUser
               ? 'bg-fl-accent text-fl-accent-fg border-fl-accent'
               : 'bg-fl-surface text-fl-fg border-fl-border'
-          }`}
+            }`}
         >
           {text}
           {streaming && (

--- a/messages/de.json
+++ b/messages/de.json
@@ -600,7 +600,15 @@
     "viewStats": "Stats anzeigen",
     "weeks": "Wochen",
     "statsTestScore": "Abschlusstestergebnis",
-    "statsDays": "Tage"
+    "statsDays": "Tage",
+    "sectionQuota": "Gesprächskontingente",
+    "quotaWeeklySessions": "Wöchentliches Sitzungslimit",
+    "quotaDailyMinutes": "Tägliches Minutenlimit",
+    "quotaUnlimitedLabel": "Unbegrenzt (0)",
+    "quotaUsedSessions": "Diese Woche genutzt",
+    "quotaUsedMinutes": "Heute genutzt",
+    "quotaSave": "Kontingente speichern",
+    "quotaSaved": "Kontingente gespeichert."
   },
   "faq": {
     "title": "FAQ",
@@ -663,7 +671,12 @@
     "sessionEnded": "Sitzung beendet",
     "tapToStart": "Sprich wenn du bereit bist",
     "you": "Du",
-    "assistant": "FreeLingo"
+    "assistant": "FreeLingo",
+    "quotaSessions": "Sitzungen diese Woche",
+    "quotaMinutes": "Minuten heute",
+    "quotaUnlimited": "Unbegrenzt",
+    "quotaExceededSessions": "Du hast alle Sitzungen dieser Woche aufgebraucht.",
+    "quotaExceededTime": "Du hast deine tägliche Übungszeit aufgebraucht."
   },
   "voiceRecorder": {
     "record": "Aufnehmen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -600,7 +600,15 @@
     "viewStats": "View stats",
     "weeks": "weeks",
     "statsTestScore": "Final test score",
-    "statsDays": "days"
+    "statsDays": "days",
+    "sectionQuota": "Conversation Quotas",
+    "quotaWeeklySessions": "Weekly sessions limit",
+    "quotaDailyMinutes": "Daily minutes limit",
+    "quotaUnlimitedLabel": "Unlimited (0)",
+    "quotaUsedSessions": "Used this week",
+    "quotaUsedMinutes": "Used today",
+    "quotaSave": "Save quotas",
+    "quotaSaved": "Quotas saved."
   },
   "faq": {
     "title": "FAQ",
@@ -663,7 +671,12 @@
     "sessionEnded": "Session ended",
     "tapToStart": "Speak when ready",
     "you": "You",
-    "assistant": "FreeLingo"
+    "assistant": "FreeLingo",
+    "quotaSessions": "Sessions this week",
+    "quotaMinutes": "Minutes today",
+    "quotaUnlimited": "Unlimited",
+    "quotaExceededSessions": "You have used all your sessions for this week.",
+    "quotaExceededTime": "You have used all your daily practice time."
   },
   "voiceRecorder": {
     "record": "Record",

--- a/messages/es.json
+++ b/messages/es.json
@@ -600,7 +600,15 @@
     "viewStats": "Ver stats",
     "weeks": "semanas",
     "statsTestScore": "Puntuación test final",
-    "statsDays": "días"
+    "statsDays": "días",
+    "sectionQuota": "Cuotas de conversación",
+    "quotaWeeklySessions": "Límite sesiones semanales",
+    "quotaDailyMinutes": "Límite minutos diarios",
+    "quotaUnlimitedLabel": "Ilimitado (0)",
+    "quotaUsedSessions": "Usadas esta semana",
+    "quotaUsedMinutes": "Usados hoy",
+    "quotaSave": "Guardar cuotas",
+    "quotaSaved": "Cuotas guardadas."
   },
   "faq": {
     "title": "FAQ",
@@ -663,7 +671,12 @@
     "sessionEnded": "Sesión finalizada",
     "tapToStart": "Habla cuando estés listo",
     "you": "Tú",
-    "assistant": "FreeLingo"
+    "assistant": "FreeLingo",
+    "quotaSessions": "Sesiones esta semana",
+    "quotaMinutes": "Minutos hoy",
+    "quotaUnlimited": "Ilimitado",
+    "quotaExceededSessions": "Has agotado todas tus sesiones de esta semana.",
+    "quotaExceededTime": "Has agotado tu tiempo de práctica diario."
   },
   "voiceRecorder": {
     "record": "Grabar",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -600,7 +600,15 @@
     "viewStats": "Voir les stats",
     "weeks": "semaines",
     "statsTestScore": "Score du test final",
-    "statsDays": "jours"
+    "statsDays": "jours",
+    "sectionQuota": "Quotas de conversation",
+    "quotaWeeklySessions": "Limite séances hebdomadaires",
+    "quotaDailyMinutes": "Limite minutes quotidiennes",
+    "quotaUnlimitedLabel": "Illimité (0)",
+    "quotaUsedSessions": "Utilisées cette semaine",
+    "quotaUsedMinutes": "Utilisées aujourd'hui",
+    "quotaSave": "Enregistrer les quotas",
+    "quotaSaved": "Quotas enregistrés."
   },
   "faq": {
     "title": "FAQ",
@@ -663,7 +671,12 @@
     "sessionEnded": "Session terminée",
     "tapToStart": "Parlez quand vous êtes prêt",
     "you": "Vous",
-    "assistant": "FreeLingo"
+    "assistant": "FreeLingo",
+    "quotaSessions": "Séances cette semaine",
+    "quotaMinutes": "Minutes aujourd'hui",
+    "quotaUnlimited": "Illimité",
+    "quotaExceededSessions": "Vous avez utilisé toutes vos séances de la semaine.",
+    "quotaExceededTime": "Vous avez utilisé tout votre temps de pratique quotidien."
   },
   "voiceRecorder": {
     "record": "Enregistrer",

--- a/messages/it.json
+++ b/messages/it.json
@@ -600,7 +600,15 @@
     "viewStats": "Vedi stats",
     "weeks": "settimane",
     "statsTestScore": "Punteggio test finale",
-    "statsDays": "giorni"
+    "statsDays": "giorni",
+    "sectionQuota": "Quote di conversazione",
+    "quotaWeeklySessions": "Limite sessioni settimanali",
+    "quotaDailyMinutes": "Limite minuti giornalieri",
+    "quotaUnlimitedLabel": "Illimitato (0)",
+    "quotaUsedSessions": "Utilizzate questa settimana",
+    "quotaUsedMinutes": "Utilizzati oggi",
+    "quotaSave": "Salva quote",
+    "quotaSaved": "Quote salvate."
   },
   "faq": {
     "title": "FAQ",
@@ -663,7 +671,12 @@
     "sessionEnded": "Sessione terminata",
     "tapToStart": "Parla quando sei pronto",
     "you": "Tu",
-    "assistant": "FreeLingo"
+    "assistant": "FreeLingo",
+    "quotaSessions": "Sessioni questa settimana",
+    "quotaMinutes": "Minuti oggi",
+    "quotaUnlimited": "Illimitato",
+    "quotaExceededSessions": "Hai esaurito tutte le sessioni di questa settimana.",
+    "quotaExceededTime": "Hai esaurito il tuo tempo di pratica giornaliero."
   },
   "voiceRecorder": {
     "record": "Registra",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -600,7 +600,15 @@
     "viewStats": "Ver stats",
     "weeks": "semanas",
     "statsTestScore": "Pontuação do teste final",
-    "statsDays": "dias"
+    "statsDays": "dias",
+    "sectionQuota": "Quotas de conversa",
+    "quotaWeeklySessions": "Limite sessões semanais",
+    "quotaDailyMinutes": "Limite minutos diários",
+    "quotaUnlimitedLabel": "Ilimitado (0)",
+    "quotaUsedSessions": "Usadas esta semana",
+    "quotaUsedMinutes": "Usados hoje",
+    "quotaSave": "Guardar quotas",
+    "quotaSaved": "Quotas guardadas."
   },
   "faq": {
     "title": "FAQ",
@@ -663,7 +671,12 @@
     "sessionEnded": "Sessão terminada",
     "tapToStart": "Fale quando estiver pronto",
     "you": "Você",
-    "assistant": "FreeLingo"
+    "assistant": "FreeLingo",
+    "quotaSessions": "Sessões esta semana",
+    "quotaMinutes": "Minutos hoje",
+    "quotaUnlimited": "Ilimitado",
+    "quotaExceededSessions": "Você usou todas as suas sessões desta semana.",
+    "quotaExceededTime": "Você usou todo o seu tempo de prática diário."
   },
   "voiceRecorder": {
     "record": "Gravar",

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.3.7**
+**1.3.8**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request introduces a comprehensive conversation quota system for users, allowing administrators to set and enforce weekly session and daily minute limits on conversations. The implementation uses Redis for live quota tracking and ensures that users cannot start a new session if their daily time limit is already exhausted, preventing wasted session slots. The changes also add OpenAI TTS speed configuration support.

**Conversation Quota System**

* Added two new fields to the `users` table/model: `conversation_weekly_sessions` and `conversation_daily_minutes`, both defaulting to 0 (unlimited). These fields are now included in user schemas and can be updated via the admin API. [[1]](diffhunk://#diff-02554ca580f5ea3178dd1cbb76cfc5b0ffab3c033ebdf983edf41a3e77a294edR1-R41) [[2]](diffhunk://#diff-e766ba496dba84ce364097d66947bad3afc257f43036bb57e1741ecb09aaab78R30-R35) [[3]](diffhunk://#diff-6f89f26da8b85c0abe62edebbb358374b67523619b8d51bd87f191c56cbf58d1R33-R34) [[4]](diffhunk://#diff-6f89f26da8b85c0abe62edebbb358374b67523619b8d51bd87f191c56cbf58d1R45-R46) [[5]](diffhunk://#diff-779d28ecc2f5d7e31f90033747661b50475f4f71c9c34c6ec83bc3a642b6e26eR195-R224)
* Implemented a new `quota_service.py` module providing Redis-backed helpers for checking and incrementing weekly sessions and daily minutes, as well as recording session durations.
* Conversation WebSocket endpoint now checks the daily minutes limit before incrementing the weekly session counter, ensuring session slots are not wasted if the daily limit is already reached. Session durations are recorded after each session. [[1]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R7-R20) [[2]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R80-R81) [[3]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R101-R148) [[4]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R161-R171) [[5]](diffhunk://#diff-a74cc90ba3ba21401e80b96a69172fec6d9dc592ed1b1ca142b455251033c9d0R12) [[6]](diffhunk://#diff-a74cc90ba3ba21401e80b96a69172fec6d9dc592ed1b1ca142b455251033c9d0R73-R74) [[7]](diffhunk://#diff-a74cc90ba3ba21401e80b96a69172fec6d9dc592ed1b1ca142b455251033c9d0R241-R249)
* Added API endpoints for retrieving live quota status for both admins (for any user) and end users (for themselves). [[1]](diffhunk://#diff-779d28ecc2f5d7e31f90033747661b50475f4f71c9c34c6ec83bc3a642b6e26eR195-R224) [[2]](diffhunk://#diff-b05ab53047dc54d983428eb226c0072641769fe81e60bf6e22f581239c95ce81R298-R312)
* Updated frontend types to include quota fields and quota status structure. ([frontend/src/app/(app)/admin/users/[id]/page.tsxR35-R45](diffhunk://#diff-fdaedff82727f54eb43f3918da3a47136089e02eb7f33e526dbecfc26416167bR35-R45))
* Documented the fix in the changelog.

**OpenAI TTS Speed Configuration**

* Added `OPENAI_TTS_SPEED` configuration to `.env.example`, `docker-compose.yml`, and backend settings, and passed it through to the OpenAI TTS service. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR52) [[2]](diffhunk://#diff-c2a439a5efd7a63613ed8d0e1a3932a9d609406d28556c435b7190940282cedbR26) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R56) [[4]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R42) [[5]](diffhunk://#diff-00b5d29dd01a1ee4db9cce1cfadc1b5a4199e2275ce50a1bb1d1abf8d21c850aL28-R32) [[6]](diffhunk://#diff-00b5d29dd01a1ee4db9cce1cfadc1b5a4199e2275ce50a1bb1d1abf8d21c850aR41)

**Other Improvements**

* Improved transcript synchronization in the conversation pipeline by sending transcript updates before audio.

These changes provide robust, configurable quota management for conversation features, supporting both operational limits and administrative oversight.