### PR TITLE
feature: fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.11] - 2026-05-09
+
+### Added
+- `POST /api/conversation/warmup` endpoint: pre-heats TTS and STT models synchronously before a session starts; frontend awaits it before opening the WebSocket so the first transcription/synthesis is instant
+- New `warming` status in `ConversationMode` — sidebar shows "Loading models..." while warmup runs, with pulsing indicator
+- `statusWarming` i18n key added to all 10 locale files
+- Contact link (`mailto:freelingo@arturocarreterocalvo.com`) added to landing page footer and docs landing nav
+- "Sobre mí" / "About me" link to `arturocarreterocalvo.com` added to landing page footer (new tab)
+- Footer link order in landing: Contact · About me · Privacy · Terms
+- Author section in Settings now includes website link (`arturocarreterocalvo.com`) and Contact (`mailto:`) alongside GitHub, with `websiteLink` and `contactLink` i18n keys in all 10 locales
+
+### Fixed
+- Version number misalignment between desktop and mobile sidebar (both now show `v1.3.11`)
+
 ## [1.3.10] - 2026-05-09
 
 ### Added

--- a/backend/app/routers/conversation.py
+++ b/backend/app/routers/conversation.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import struct
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
 
 logger = logging.getLogger(__name__)
@@ -12,6 +14,7 @@ from sqlalchemy import select
 
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal
+from app.core.deps import get_current_user
 from app.core.security import decode_access_token
 from app.models.study_plan import StudyPlan
 from app.models.user import User
@@ -20,6 +23,62 @@ from app.services.llm_adapter import llm_adapter
 from app.services.quota_service import check_and_increment_sessions, check_daily_minutes, check_weekly_minutes
 
 router = APIRouter(tags=["conversation"])
+
+
+def _make_silence_wav(duration_ms: int = 100, sample_rate: int = 16000) -> bytes:
+    """Return a minimal valid PCM WAV with silence (for STT warmup)."""
+    num_samples = sample_rate * duration_ms // 1000
+    data = b"\x00" * (num_samples * 2)  # 16-bit mono
+    byte_rate = sample_rate * 2
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF", 36 + len(data), b"WAVE",
+        b"fmt ", 16, 1, 1, sample_rate, byte_rate, 2, 16,
+        b"data", len(data),
+    )
+    return header + data
+
+
+@router.post("/api/conversation/warmup")
+async def conversation_warmup(
+    request: Request,
+    _current_user: User = Depends(get_current_user),
+) -> JSONResponse:
+    """Pre-heat TTS and STT services before a conversation session starts.
+
+    Awaits model loading synchronously so the caller knows the models are
+    ready before opening the WebSocket. The frontend must await this call
+    and only then connect the WebSocket.
+    """
+    tts_service = getattr(request.app.state, "tts_service", None)
+    stt_service = getattr(request.app.state, "stt_service", None)
+
+    tasks = []
+    if tts_service:
+        tasks.append(_warmup_tts(tts_service))
+    if stt_service:
+        tasks.append(_warmup_stt(stt_service))
+    if tasks:
+        await asyncio.gather(*tasks)
+
+    return JSONResponse({"status": "ready"})
+
+
+async def _warmup_tts(tts_service: object) -> None:
+    try:
+        await tts_service.synthesize("ready")  # type: ignore[union-attr]
+        logger.info("[warmup] TTS ready")
+    except Exception as exc:
+        logger.warning("[warmup] TTS warmup error: %s", exc)
+
+
+async def _warmup_stt(stt_service: object) -> None:
+    try:
+        wav = _make_silence_wav()
+        await stt_service.transcribe(wav, "warmup.wav", "audio/wav")  # type: ignore[union-attr]
+        logger.info("[warmup] STT ready")
+    except Exception as exc:
+        logger.warning("[warmup] STT warmup error: %s", exc)
 
 
 @router.websocket("/ws/conversation")

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -223,7 +223,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.7</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.11</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -342,7 +342,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.10</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.11</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -436,15 +436,33 @@ export default function SettingsPage() {
           <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">{t('sectionAuthor')}</span>
         </div>
         <p className="font-mono text-sm text-fl-fg">{t('authorDescription')}</p>
-        <a
-          href="https://github.com/artcc"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 mt-3 font-mono text-xs text-fl-muted-2 hover:text-fl-fg hover:underline transition-colors"
-        >
-          <ExternalLink className="w-3.5 h-3.5" />
-          {t('githubProfile')}
-        </a>
+        <div className="flex flex-col gap-2 mt-3">
+          <a
+            href="https://arturocarreterocalvo.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 font-mono text-xs text-fl-muted-2 hover:text-fl-fg hover:underline transition-colors"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            {t('websiteLink')}
+          </a>
+          <a
+            href="https://github.com/artcc"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 font-mono text-xs text-fl-muted-2 hover:text-fl-fg hover:underline transition-colors"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            {t('githubProfile')}
+          </a>
+          <a
+            href="mailto:freelingo@arturocarreterocalvo.com"
+            className="inline-flex items-center gap-2 font-mono text-xs text-fl-muted-2 hover:text-fl-fg hover:underline transition-colors"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            {t('contactLink')}
+          </a>
+        </div>
       </div>
 
       {/* Legal */}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -85,11 +85,17 @@ export default async function Home() {
             © {new Date().getFullYear()} FreeLingo · {t('footer')}
           </span>
           <div className="flex gap-6">
-            <Link href="/terms?from=landing" className="font-mono text-fl-hint text-fl-muted-3 hover:text-fl-muted-1 tracking-widest uppercase transition-colors">
-              {t('terms')}
-            </Link>
+            <a href="mailto:freelingo@arturocarreterocalvo.com" className="font-mono text-fl-hint text-fl-muted-3 hover:text-fl-muted-1 tracking-widest uppercase transition-colors">
+              {t('contact')}
+            </a>
+            <a href="https://arturocarreterocalvo.com" target="_blank" rel="noopener noreferrer" className="font-mono text-fl-hint text-fl-muted-3 hover:text-fl-muted-1 tracking-widest uppercase transition-colors">
+              {t('aboutMe')}
+            </a>
             <Link href="/privacy?from=landing" className="font-mono text-fl-hint text-fl-muted-3 hover:text-fl-muted-1 tracking-widest uppercase transition-colors">
               {t('privacy')}
+            </Link>
+            <Link href="/terms?from=landing" className="font-mono text-fl-hint text-fl-muted-3 hover:text-fl-muted-1 tracking-widest uppercase transition-colors">
+              {t('terms')}
             </Link>
           </div>
         </div>

--- a/frontend/src/components/conversation/ConversationMode.tsx
+++ b/frontend/src/components/conversation/ConversationMode.tsx
@@ -251,7 +251,7 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
   )
 
   // ─── Session lifecycle ────────────────────────────────────────────────────
-  function handleStart() {
+  async function handleStart() {
     if (!accessToken || vad.loading || vad.errored) return
 
     // AudioContext MUST be created during a user-gesture (this click handler)
@@ -270,6 +270,13 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
     setAssistantSpeaking(false)
     refreshQuota()
 
+    // Trigger model warmup on TTS/STT services and WAIT for them to be ready
+    // before opening the WebSocket. Models are loaded lazily by the backend;
+    // this ensures the first transcription/synthesis in the session is fast.
+    // Runs in parallel with VAD mic permission request.
+    setStatus('warming')
+    const warmupPromise = apiFetch('/api/conversation/warmup', { method: 'POST' }).catch(() => undefined)
+
     // Start mic (requests permission if not already granted)
     vad.start().catch((e: unknown) => {
       setErrorMsg(e instanceof Error ? e.message : t('errorMic'))
@@ -277,6 +284,7 @@ export default function ConversationMode({ initialContext }: { initialContext?: 
       setSessionActive(false)
     })
 
+    await warmupPromise
     connectWs(accessToken, initialContext)
   }
 

--- a/frontend/src/components/conversation/StatusIndicator.tsx
+++ b/frontend/src/components/conversation/StatusIndicator.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl'
 export type ConvStatus =
   | 'loading'
   | 'ready'
+  | 'warming'
   | 'connecting'
   | 'live'
   | 'ended'
@@ -23,6 +24,9 @@ export default function StatusIndicator({ status, userSpeaking, assistantSpeakin
 
   if (status === 'loading') {
     label = t('statusLoading')
+  } else if (status === 'warming') {
+    label = t('statusWarming')
+    pulse = true
   } else if (status === 'connecting') {
     label = t('statusConnecting')
     pulse = true

--- a/messages/de.json
+++ b/messages/de.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Sprich in Echtzeit mit deinem Tutor. Sprachaktiviert, sofortige Antwort, kein Abwarten.",
     "footer": "Open Source · Selbst hosten (kostenlos) oder gehosteten Dienst abonnieren",
     "terms": "AGB",
-    "privacy": "Datenschutz"
+    "privacy": "Datenschutz",
+    "contact": "Kontakt",
+    "aboutMe": "Über mich"
   },
   "common": {
     "loading": "Laden...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Datenschutzerklärung",
     "sectionAuthor": "Autor",
     "authorDescription": "Erstellt von Arturo Carretero Calvo",
+    "websiteLink": "Website",
     "githubProfile": "GitHub-Profil",
+    "contactLink": "Kontakt",
     "deleteAccount": "Konto löschen",
     "deleteAccountTitle": "Konto löschen",
     "deleteAccountMessage": "Diese Aktion löscht dein Konto und alle deine Daten dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -659,6 +663,7 @@
     "startNew": "Neue Sitzung",
     "statusLoading": "Sprachmodell wird geladen...",
     "statusReady": "Bereit",
+    "statusWarming": "Modelle laden...",
     "statusConnecting": "Verbinde...",
     "statusListening": "Höre zu...",
     "statusDetecting": "Sprache wird erkannt...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Talk to your tutor in real time. Voice-activated, instant response, no turn-taking.",
     "footer": "Open source · Self-host free or subscribe to the hosted service",
     "terms": "Terms",
-    "privacy": "Privacy"
+    "privacy": "Privacy",
+    "contact": "Contact",
+    "aboutMe": "About me"
   },
   "common": {
     "loading": "Loading...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Privacy Policy",
     "sectionAuthor": "Author",
     "authorDescription": "Built by Arturo Carretero Calvo",
+    "websiteLink": "Website",
     "githubProfile": "GitHub profile",
+    "contactLink": "Contact",
     "deleteAccount": "Delete Account",
     "deleteAccountTitle": "Delete Account",
     "deleteAccountMessage": "This will permanently delete your account and all your data. This action cannot be undone.",
@@ -659,6 +663,7 @@
     "startNew": "Start New Session",
     "statusLoading": "Loading voice model...",
     "statusReady": "Ready",
+    "statusWarming": "Loading models...",
     "statusConnecting": "Connecting...",
     "statusListening": "Listening...",
     "statusDetecting": "Detecting speech...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Habla con tu tutor en tiempo real. Voz activada, respuesta instantánea, sin turnos.",
     "footer": "Código abierto · Autoalójalo gratis o suscríbete al servicio alojado",
     "terms": "Términos",
-    "privacy": "Privacidad"
+    "privacy": "Privacidad",
+    "contact": "Contacto",
+    "aboutMe": "Sobre mí"
   },
   "common": {
     "loading": "Cargando...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Política de Privacidad",
     "sectionAuthor": "Autor",
     "authorDescription": "Creado por Arturo Carretero Calvo",
+    "websiteLink": "Sitio web",
     "githubProfile": "Perfil de GitHub",
+    "contactLink": "Contacto",
     "deleteAccount": "Eliminar cuenta",
     "deleteAccountTitle": "Eliminar cuenta",
     "deleteAccountMessage": "Esta acción eliminará tu cuenta y todos tus datos de forma permanente. Esta acción no se puede deshacer.",
@@ -659,6 +663,7 @@
     "startNew": "Nueva sesión",
     "statusLoading": "Cargando modelo de voz...",
     "statusReady": "Listo",
+    "statusWarming": "Cargando modelos...",
     "statusConnecting": "Conectando...",
     "statusListening": "Escuchando...",
     "statusDetecting": "Detectando voz...",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Parlez à votre tuteur en temps réel. Activation vocale, réponse instantanée, sans attendre votre tour.",
     "footer": "Open source · Auto-hébergez gratuitement ou abonnez-vous au service hébergé",
     "terms": "CGU",
-    "privacy": "Confidentialité"
+    "privacy": "Confidentialité",
+    "contact": "Contact",
+    "aboutMe": "À propos"
   },
   "common": {
     "loading": "Chargement...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Politique de confidentialité",
     "sectionAuthor": "Auteur",
     "authorDescription": "Créé par Arturo Carretero Calvo",
+    "websiteLink": "Site web",
     "githubProfile": "Profil GitHub",
+    "contactLink": "Contact",
     "deleteAccount": "Supprimer le compte",
     "deleteAccountTitle": "Supprimer le compte",
     "deleteAccountMessage": "Cette action supprimera définitivement votre compte et toutes vos données. Cette action est irréversible.",
@@ -659,6 +663,7 @@
     "startNew": "Nouvelle session",
     "statusLoading": "Chargement du modèle vocal...",
     "statusReady": "Prêt",
+    "statusWarming": "Chargement des modèles...",
     "statusConnecting": "Connexion...",
     "statusListening": "En écoute...",
     "statusDetecting": "Détection de la parole...",

--- a/messages/it.json
+++ b/messages/it.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Parla con il tuo tutor in tempo reale. Attivazione vocale, risposta istantanea, senza turni.",
     "footer": "Open source · Self-hostalo gratis o abbonati al servizio ospitato",
     "terms": "Termini",
-    "privacy": "Privacy"
+    "privacy": "Privacy",
+    "contact": "Contatto",
+    "aboutMe": "Chi sono"
   },
   "common": {
     "loading": "Caricamento...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Informativa sulla Privacy",
     "sectionAuthor": "Autore",
     "authorDescription": "Creato da Arturo Carretero Calvo",
+    "websiteLink": "Sito web",
     "githubProfile": "Profilo GitHub",
+    "contactLink": "Contatto",
     "deleteAccount": "Elimina account",
     "deleteAccountTitle": "Elimina account",
     "deleteAccountMessage": "Questa azione eliminerà definitivamente il tuo account e tutti i tuoi dati. Questa azione non può essere annullata.",
@@ -659,6 +663,7 @@
     "startNew": "Nuova sessione",
     "statusLoading": "Caricamento modello vocale...",
     "statusReady": "Pronto",
+    "statusWarming": "Caricamento modelli...",
     "statusConnecting": "Connessione...",
     "statusListening": "In ascolto...",
     "statusDetecting": "Rilevamento voce...",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Praat met je tutor in realtime. Spraakgestuurd, directe reactie, zonder beurtneming.",
     "footer": "Open source · Zelf hosten gratis of abonneer op de gehoste dienst",
     "terms": "Gebruiksvoorwaarden",
-    "privacy": "Privacy"
+    "privacy": "Privacy",
+    "contact": "Contact",
+    "aboutMe": "Over mij"
   },
   "common": {
     "loading": "Laden...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Privacybeleid",
     "sectionAuthor": "Auteur",
     "authorDescription": "Gebouwd door Arturo Carretero Calvo",
+    "websiteLink": "Website",
     "githubProfile": "GitHub-profiel",
+    "contactLink": "Contact",
     "deleteAccount": "Account verwijderen",
     "deleteAccountTitle": "Account verwijderen",
     "deleteAccountMessage": "Dit verwijdert je account en alle bijbehorende gegevens permanent. Deze actie kan niet ongedaan worden gemaakt.",
@@ -659,6 +663,7 @@
     "startNew": "Nieuwe sessie starten",
     "statusLoading": "Spraakmodel laden...",
     "statusReady": "Klaar",
+    "statusWarming": "Modellen laden...",
     "statusConnecting": "Verbinden...",
     "statusListening": "Luisteren...",
     "statusDetecting": "Spraak detecteren...",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Rozmawiaj z korepetytorem w czasie rzeczywistym. Aktywacja głosem, natychmiastowa odpowiedź.",
     "footer": "Open source · Hostuj samodzielnie za darmo lub subskrybuj usługę hostowaną",
     "terms": "Regulamin",
-    "privacy": "Prywatność"
+    "privacy": "Prywatność",
+    "contact": "Kontakt",
+    "aboutMe": "O mnie"
   },
   "common": {
     "loading": "Ładowanie...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Polityka prywatności",
     "sectionAuthor": "Autor",
     "authorDescription": "Zbudowane przez Arturo Carretero Calvo",
+    "websiteLink": "Strona internetowa",
     "githubProfile": "Profil GitHub",
+    "contactLink": "Kontakt",
     "deleteAccount": "Usuń konto",
     "deleteAccountTitle": "Usuń konto",
     "deleteAccountMessage": "Spowoduje to trwałe usunięcie Twojego konta i wszystkich danych. Tej operacji nie można cofnąć.",
@@ -659,6 +663,7 @@
     "startNew": "Rozpocznij nową sesję",
     "statusLoading": "Ładowanie modelu głosowego...",
     "statusReady": "Gotowy",
+    "statusWarming": "Ładowanie modeli...",
     "statusConnecting": "Łączenie...",
     "statusListening": "Słuchanie...",
     "statusDetecting": "Wykrywanie mowy...",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Fale com seu tutor em tempo real. Ativação por voz, resposta instantânea, sem esperar a vez.",
     "footer": "Código aberto · Auto-hospede gratuitamente ou assine o serviço hospedado",
     "terms": "Termos",
-    "privacy": "Privacidade"
+    "privacy": "Privacidade",
+    "contact": "Contato",
+    "aboutMe": "Sobre mim"
   },
   "common": {
     "loading": "Carregando...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Política de Privacidade",
     "sectionAuthor": "Autor",
     "authorDescription": "Criado por Arturo Carretero Calvo",
+    "websiteLink": "Website",
     "githubProfile": "Perfil do GitHub",
+    "contactLink": "Contato",
     "deleteAccount": "Excluir conta",
     "deleteAccountTitle": "Excluir conta",
     "deleteAccountMessage": "Esta ação excluirá permanentemente sua conta e todos os seus dados. Esta ação não pode ser desfeita.",
@@ -659,6 +663,7 @@
     "startNew": "Nova sessão",
     "statusLoading": "A carregar modelo de voz...",
     "statusReady": "Pronto",
+    "statusWarming": "Carregando modelos...",
     "statusConnecting": "A ligar...",
     "statusListening": "A ouvir...",
     "statusDetecting": "A detetar voz...",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Vorbește cu tutorele în timp real. Controlat prin voce, răspuns imediat, fără rânduri.",
     "footer": "Sursă deschisă · Găzduire proprie gratuită sau abonament la serviciul găzduit",
     "terms": "Termeni și condiții",
-    "privacy": "Confidențialitate"
+    "privacy": "Confidențialitate",
+    "contact": "Contact",
+    "aboutMe": "Despre mine"
   },
   "common": {
     "loading": "Se încarcă...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Politică de confidențialitate",
     "sectionAuthor": "Autor",
     "authorDescription": "Creat de Arturo Carretero Calvo",
+    "websiteLink": "Site web",
     "githubProfile": "Profil GitHub",
+    "contactLink": "Contact",
     "deleteAccount": "Șterge contul",
     "deleteAccountTitle": "Șterge contul",
     "deleteAccountMessage": "Acest lucru va șterge permanent contul tău și toate datele asociate. Această acțiune nu poate fi anulată.",
@@ -659,6 +663,7 @@
     "startNew": "Începe o sesiune nouă",
     "statusLoading": "Se încarcă modelul vocal...",
     "statusReady": "Gata",
+    "statusWarming": "Se încarcă modelele...",
     "statusConnecting": "Se conectează...",
     "statusListening": "Ascultă...",
     "statusDetecting": "Se detectează vocea...",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -12,7 +12,9 @@
     "feature3Desc": "Говорите с репетитором в реальном времени. Управление голосом, мгновенный ответ, без очереди.",
     "footer": "Открытый исходный код · Самостоятельный хостинг бесплатно или подписка на облачный сервис",
     "terms": "Условия использования",
-    "privacy": "Конфиденциальность"
+    "privacy": "Конфиденциальность",
+    "contact": "Контакт",
+    "aboutMe": "О себе"
   },
   "common": {
     "loading": "Загрузка...",
@@ -155,7 +157,9 @@
     "privacyPolicy": "Политика конфиденциальности",
     "sectionAuthor": "Автор",
     "authorDescription": "Создано Arturo Carretero Calvo",
+    "websiteLink": "Веб-сайт",
     "githubProfile": "Профиль GitHub",
+    "contactLink": "Контакт",
     "deleteAccount": "Удалить аккаунт",
     "deleteAccountTitle": "Удалить аккаунт",
     "deleteAccountMessage": "Это навсегда удалит ваш аккаунт и все связанные данные. Это действие нельзя отменить.",
@@ -659,6 +663,7 @@
     "startNew": "Начать новую сессию",
     "statusLoading": "Загрузка голосовой модели...",
     "statusReady": "Готово",
+    "statusWarming": "Загрузка моделей...",
     "statusConnecting": "Подключение...",
     "statusListening": "Слушаю...",
     "statusDetecting": "Обнаружение речи...",

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.3.10**
+**1.3.11**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request introduces a new backend warmup endpoint to pre-load TTS and STT models before starting a conversation session, ensuring instant response for the first transcription or synthesis. The frontend is updated to call this endpoint and display a new "warming" status with a pulsing indicator while models load. Additionally, contact and author links have been enhanced in the UI, and i18n keys have been added and updated across all locales. There are also minor fixes to version display and link ordering in the footer.

**Backend: Conversation warmup and model preloading**
- Added `POST /api/conversation/warmup` endpoint to synchronously pre-heat TTS and STT models before a session, ensuring the frontend only opens the WebSocket after models are ready. Includes helper functions for TTS and STT warmup and a minimal WAV generator for STT. (`backend/app/routers/conversation.py`) [[1]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R5-R8) [[2]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R17) [[3]](diffhunk://#diff-ccb7a80df199ad3bfc97af85b9357179351cd34d58f2f9a4c6625064dff55307R28-R83)

**Frontend: Session startup and status UI**
- Modified conversation start logic to POST to the warmup endpoint and await completion before opening the WebSocket, setting a new `warming` status during this phase. (`frontend/src/components/conversation/ConversationMode.tsx`) [[1]](diffhunk://#diff-9f45dafa806858587eede8733af8eb8b66be90644255fc99fd69f918dc4431caL254-R254) [[2]](diffhunk://#diff-9f45dafa806858587eede8733af8eb8b66be90644255fc99fd69f918dc4431caR273-R287)
- Added new `warming` status to the conversation status indicator, with a pulsing effect and i18n label. (`frontend/src/components/conversation/StatusIndicator.tsx`) [[1]](diffhunk://#diff-5cbeded94eec3f59bab21a11ff9b643d0f1b2380f8d8910daecaac4f304fe2b2R6) [[2]](diffhunk://#diff-5cbeded94eec3f59bab21a11ff9b643d0f1b2380f8d8910daecaac4f304fe2b2R27-R29)

**UI/UX: Author and contact links, footer updates**
- Added "Contact" (`mailto:`) and "About me" (personal website) links to the landing page footer and reordered footer links. (`frontend/src/app/page.tsx`)
- Enhanced the author section in Settings to include website and contact links alongside GitHub, with proper i18n keys. (`frontend/src/app/(app)/settings/page.tsx`)

**Internationalization**
- Added/updated `contact`, `aboutMe`, `websiteLink`, `contactLink`, and `statusWarming` keys in all 10 locale files, ensuring full translation coverage for new UI text. (`messages/*.json`) [[1]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158L15-R17) [[2]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158R160-R162) [[3]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158R666) [[4]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL15-R17) [[5]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeR160-R162) [[6]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeR666) [[7]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2L15-R17) [[8]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2R160-R162) [[9]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2R666) [[10]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877L15-R17) [[11]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877R160-R162) [[12]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877R666) [[13]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778L15-R17) [[14]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778R160-R162) [[15]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778R666)

**Other fixes**
- Fixed version number misalignment between desktop and mobile sidebars (now both show `v1.3.11`). (`frontend/src/app/(app)/layout.tsx`) [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L226-R226) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L345-R345)
- Updated the changelog for release 1.3.11, documenting all notable changes. (`CHANGELOG.md`)