### PR TITLE
feature: deploy to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.13] - 2026-05-09
+
+### Fixed
+- `/forgot-password`, `/reset-password`, and `/verify-email` added to `PUBLIC_ROUTES` in Next.js middleware — unauthenticated users were redirected back to `/login` before reaching these pages, making "Forgot your password?" appear to do nothing
+- Redundant Redis delete of invite token in `POST /api/auth/register` removed — the token was already deleted during validation; the second `await redis.delete(...)` call was unreachable when `ALLOW_REGISTRATION=true` and a no-op otherwise
+
+### Added
+- 4 edge-case tests for email system: `test_resend_verification_no_email` (→ 400), `test_resend_verification_email_disabled` (→ 503), `test_verify_email_token_consumed_after_use` (second call → 400), `test_reset_password_token_consumed_after_use` (second call → 400)
+
 ## [1.3.12] - 2026-05-09
 
 ### Added

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -230,7 +230,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.12</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.13</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -349,7 +349,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.12</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.13</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-const PUBLIC_ROUTES = ['/login', '/register', '/terms', '/privacy']
+const PUBLIC_ROUTES = ['/login', '/register', '/terms', '/privacy', '/forgot-password', '/reset-password', '/verify-email']
 const PUBLIC_EXACT = ['/']
 const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'pt', 'de', 'it', 'pl', 'nl', 'ro', 'ru'] as const
 type Locale = (typeof SUPPORTED_LOCALES)[number]

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.3.12**
+**1.3.13**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request updates the project to version 1.3.13 and addresses issues with authentication-related routes, improves test coverage for email edge cases, and removes redundant code. The most important changes are summarized below.

Authentication and routing fixes:
* Added `/forgot-password`, `/reset-password`, and `/verify-email` to the `PUBLIC_ROUTES` array in `middleware.ts`, ensuring unauthenticated users can access these pages and fixing an issue where users were redirected back to `/login` when trying to use "Forgot your password?"

Code cleanup:
* Removed a redundant Redis delete operation for invite tokens in the `POST /api/auth/register` endpoint, as the token was already deleted during validation and the second call was unreachable or a no-op.

Testing improvements:
* Added four edge-case tests for the email system: handling resend verification with no email (400), resend verification with email disabled (503), and verifying that email and reset password tokens are consumed after use (second call returns 400).

Version bump and documentation:
* Updated version number references in `layout.tsx` and `version.md` from `1.3.12` to `1.3.13`. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L233-R233) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L352-R352) [[3]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3)
* Added a new entry for `1.3.13` in `CHANGELOG.md` documenting these changes.