### PR TITLE
feature: fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.14] - 2026-05-09
+
+### Added
+- `/health` endpoint now checks DB, Redis, TTS, and STT dependencies; returns HTTP 503 with `{"status": "degraded", "checks": {...}}` if any dependency is unreachable (previously always returned 200)
+- `health()` method added to `KokoroTTSService`, `OpenAITTSService`, `WhisperSTTService`, and `OpenAISTTService`
+- `SECRET_KEY` startup validation in `lifespan`: server refuses to start if the value contains `CHANGE_ME` or is shorter than 32 characters
+- `error.tsx` (global error boundary) and `not-found.tsx` (404) pages with FreeLingo branded design — monospaced layout consistent with the rest of the app; i18n in all 10 locales (`error.*`, `notFound.*`)
+- Cookie consent banner (`CookieBanner` component) fixed to the bottom of every page; persists acceptance in `localStorage`; links to Privacy Policy; i18n in all 10 locales (`cookieBanner.*`)
+- Welcome email sent on registration (`send_welcome_email`): 3-step onboarding guide (Assessment → Study Plan → first lesson); HTML template `welcome.html` follows the same design as `verify_email.html` and `reset_password.html`; i18n in all 10 locales
+- `UVICORN_WORKERS` environment variable (default `4` in `docker-compose.yml`, `1` in `Dockerfile`); documented in `.env.example` with sizing guidance (`2 × CPU cores + 1`)
+
 ## [1.3.13] - 2026-05-09
 
 ### Fixed

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -230,7 +230,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.13</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.14</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -349,7 +349,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.13</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.14</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.3.13**
+**1.3.14**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request releases version 1.3.14, introducing several new features and improvements focused on health checks, onboarding, compliance, and user experience. The version bump is reflected throughout the codebase and documentation.

**Major new features and improvements:**

*Health checks and startup validation:*
- The `/health` endpoint now performs comprehensive checks for DB, Redis, TTS, and STT dependencies, returning HTTP 503 with detailed status if any are unreachable, instead of always returning 200.
- A `health()` method has been added to the `KokoroTTSService`, `OpenAITTSService`, `WhisperSTTService`, and `OpenAISTTService` classes.
- The server now validates `SECRET_KEY` on startup, refusing to start if it contains `CHANGE_ME` or is shorter than 32 characters.

*User experience and onboarding:*
- A global error boundary (`error.tsx`) and a custom 404 page (`not-found.tsx`) have been added, both featuring FreeLingo branding and full i18n support for all 10 locales.
- A cookie consent banner (`CookieBanner` component) is now shown at the bottom of every page, with persistent acceptance and localized messaging.
- New welcome emails are sent on registration, guiding users through onboarding steps and using a branded HTML template with full i18n support.

*Configuration and documentation:*
- The `UVICORN_WORKERS` environment variable is introduced and documented, with sensible defaults and sizing guidance.

*Version updates:*
- The project version is bumped to 1.3.14 in the UI (`AppLayout`), documentation (`CHANGELOG.md`, `specs/version.md`), and all relevant places. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L233-R233) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L352-R352) [[3]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R18)