### PR TITLE
feature: deploy to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.15] - 2026-05-09
+
+### Fixed
+- `Strict-Transport-Security` header removed from backend middleware — the header was emitted over plain HTTP internally (Cloudflare tunnel terminates TLS), causing browsers to cache an HSTS policy that blocked subsequent visits with a hard security error. HSTS should be configured at the Cloudflare edge (SSL/TLS → Edge Certificates → HSTS), not by the origin server
+
 ## [1.3.14] - 2026-05-09
 
 ### Added

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -85,8 +85,6 @@ async def security_headers_middleware(request: Request, call_next) -> Response:
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["X-XSS-Protection"] = "0"  # Modern browsers ignore it; CSP is the right tool
     response.headers["Content-Security-Policy"] = "default-src 'self'; object-src 'none'; base-uri 'self'"  # API-only responses (JSON/binary)
-    if settings.COOKIE_SECURE:
-        response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
     return response
 
 app.include_router(auth.router)

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -230,7 +230,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.14</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.15</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -349,7 +349,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.14</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.3.15</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.3.14**
+**1.3.15**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request updates the project to version 1.3.15 and fixes a security-related middleware issue. The most important change is the removal of the `Strict-Transport-Security` (HSTS) header from the backend, which previously caused browsers to cache an invalid security policy due to the project's use of Cloudflare for TLS termination. The version number is also updated throughout the project to reflect the new release.

Security fix:

* Removed the `Strict-Transport-Security` header from the backend middleware in `main.py` to prevent browsers from caching an HSTS policy when TLS is terminated at Cloudflare. The correct place to configure HSTS is at the Cloudflare edge, not the origin server. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L88-L89) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12)

Version bump:

* Updated version references from `1.3.14` to `1.3.15` in the frontend layout (`layout.tsx`) and version documentation (`specs/version.md`). [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L233-R233) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L352-R352) [[3]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3)