### PR TITLE
feature: deploy to main

### DIFF
--- a/backend/app/routers/study_plan.py
+++ b/backend/app/routers/study_plan.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
-from app.core.deps import require_subscription
+from app.core.deps import get_current_user, require_subscription
 from app.models.lesson import Exercise, Lesson
 from app.models.study_plan import StudyPlan
 from app.models.user import User
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/api/study-plan", tags=["study-plan"])
 
 @router.get("/current", response_model=Optional[StudyPlanResponse])
 async def get_current_plan(
-    current_user: User = Depends(require_subscription),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(

--- a/frontend/src/app/(app)/admin/users/[id]/page.tsx
+++ b/frontend/src/app/(app)/admin/users/[id]/page.tsx
@@ -33,6 +33,9 @@ interface AdminUser {
   native_language: string
   is_active: boolean
   is_verified: boolean
+  subscription_status: string
+  subscription_ends_at: string | null
+  stripe_customer_id: string | null
   conversation_weekly_sessions: number
   conversation_daily_minutes: number
   conversation_weekly_minutes: number
@@ -247,6 +250,22 @@ export default function AdminUserStatsPage() {
           </div>
         )}
         <StatRow label={t('fieldNativeLanguage')} value={tLang(user.native_language as 'es' | 'fr' | 'pt' | 'de' | 'it' | 'pl' | 'nl' | 'ro' | 'ru')} />
+        <StatRow
+          label="Subscription"
+          value={
+            <span className={`font-mono text-fl-hint tracking-widest uppercase border px-2 py-0.5 ${user.subscription_status === 'active' ? 'border-green-500/40 text-green-400'
+                : user.subscription_status === 'trialing' ? 'border-blue-500/40 text-blue-400'
+                  : user.subscription_status === 'past_due' ? 'border-yellow-500/40 text-yellow-400'
+                    : 'border-fl-border text-fl-muted-2'
+              }`}>{user.subscription_status}</span>
+          }
+        />
+        {user.subscription_ends_at && (
+          <StatRow label="Ends / Renews" value={new Date(user.subscription_ends_at).toLocaleDateString()} />
+        )}
+        {user.stripe_customer_id && (
+          <StatRow label="Stripe Customer" value={user.stripe_customer_id} />
+        )}
       </Section>
 
       {/* Study plan */}

--- a/frontend/src/app/(app)/admin/users/page.tsx
+++ b/frontend/src/app/(app)/admin/users/page.tsx
@@ -15,6 +15,7 @@ interface AdminUserItem {
   role: string
   native_language: string
   is_active: boolean
+  subscription_status: string
 }
 
 const LANGUAGES = ['es', 'fr', 'pt', 'de', 'it', 'pl', 'nl', 'ro', 'ru'] as const
@@ -269,6 +270,15 @@ export default function AdminUsersPage() {
                       }`}>{u.role === 'admin' ? t('roleAdmin') : t('roleUser')}</span>
                     {!u.is_active && (
                       <span className="font-mono text-fl-hint tracking-widest uppercase border border-fl-error/30 text-fl-error-fg px-2 py-0.5">{t('inactive')}</span>
+                    )}
+                    {u.subscription_status === 'active' && (
+                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-green-500/40 text-green-400 px-2 py-0.5">active</span>
+                    )}
+                    {u.subscription_status === 'trialing' && (
+                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-blue-500/40 text-blue-400 px-2 py-0.5">trial</span>
+                    )}
+                    {u.subscription_status === 'past_due' && (
+                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-yellow-500/40 text-yellow-400 px-2 py-0.5">past due</span>
                     )}
                   </div>
                   <p className="font-mono text-fl-label text-fl-muted-2 break-all">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import { cookies, headers } from 'next/headers'
+import { cookies } from 'next/headers'
 import { getTranslations } from 'next-intl/server'
 
 export default async function Home() {
@@ -10,14 +10,14 @@ export default async function Home() {
   const tCommon = await getTranslations('common')
   const tBilling = await getTranslations('billing')
 
-  // Fetch Stripe config server-side to conditionally show pricing section
+  // Fetch Stripe config server-side to conditionally show pricing section.
+  // Use BACKEND_URL directly to avoid the Next.js rewrite proxy chain,
+  // which can fail in SSR context (self-referential fetch + SSL issues).
   let stripeEnabled = false
   let trialDays = 7
   try {
-    const hdrs = await headers()
-    const host = hdrs.get('host') ?? 'localhost'
-    const proto = process.env.NODE_ENV === 'production' ? 'https' : 'http'
-    const configRes = await fetch(`${proto}://${host}/api/config`, { next: { revalidate: 3600 } })
+    const backendUrl = process.env.BACKEND_URL || 'http://backend:8000'
+    const configRes = await fetch(`${backendUrl}/api/config`, { next: { revalidate: 3600 } })
     if (configRes.ok) {
       const cfg = await configRes.json()
       stripeEnabled = cfg.stripe_enabled ?? false
@@ -149,7 +149,7 @@ export default async function Home() {
                 </span>
               </div>
               <p className="font-mono text-xl font-bold text-fl-fg">
-                119<span className="text-sm text-fl-muted-1">€ / {tBilling('year')}</span>
+                149.50<span className="text-sm text-fl-muted-1">€ / {tBilling('year')}</span>
               </p>
               <ul className="flex flex-col gap-1.5">
                 {['feature1', 'feature2', 'feature3', 'feature4', 'feature5'].map((k) => (

--- a/frontend/src/components/billing/PaywallBanner.tsx
+++ b/frontend/src/components/billing/PaywallBanner.tsx
@@ -69,7 +69,7 @@ export function PaywallBanner() {
             disabled={loading !== null}
             className="w-full font-mono text-xs tracking-widest uppercase py-3 px-4 border border-fl-border text-fl-muted-1 hover:text-fl-fg hover:border-fl-border-2 disabled:opacity-50 transition-colors"
           >
-            {loading === 'yearly' ? '…' : t('planYearly', { price: '119' })}
+            {loading === 'yearly' ? '…' : t('planYearly', { price: '149.50' })}
           </button>
         </div>
 


### PR DESCRIPTION
This pull request introduces improvements to user subscription visibility in the admin interface, updates the yearly subscription price in both the frontend and paywall, and refines backend dependencies for study plan retrieval. The main focus is on enhancing admin tools for managing and viewing user subscription status, as well as correcting how subscription data is fetched and displayed.

**Admin interface improvements:**

* Added `subscription_status`, `subscription_ends_at`, and `stripe_customer_id` fields to the `AdminUser` interface in `page.tsx`, and displayed these fields in the user details panel, including colored status badges and renewal/end dates. (`frontend/src/app/(app)/admin/users/[id]/page.tsx`) ([frontend/src/app/(app)/admin/users/[id]/page.tsxR36-R38](diffhunk://#diff-fdaedff82727f54eb43f3918da3a47136089e02eb7f33e526dbecfc26416167bR36-R38), [frontend/src/app/(app)/admin/users/[id]/page.tsxR253-R268](diffhunk://#diff-fdaedff82727f54eb43f3918da3a47136089e02eb7f33e526dbecfc26416167bR253-R268))
* Added `subscription_status` to the `AdminUserItem` interface and displayed subscription status badges in the admin user list. (`frontend/src/app/(app)/admin/users/page.tsx`) [[1]](diffhunk://#diff-284f6e50bfbe196253a33dc10dc57918da86a764e38c65f39b367547ae27a594R18) [[2]](diffhunk://#diff-284f6e50bfbe196253a33dc10dc57918da86a764e38c65f39b367547ae27a594R274-R282)

**Frontend pricing updates:**

* Updated the yearly subscription price from 119€ to 149.50€ in both the home page and the paywall banner. (`frontend/src/app/page.tsx`, `frontend/src/components/billing/PaywallBanner.tsx`) [[1]](diffhunk://#diff-bc32312b6e0185cbc840269d0632c2a90ed907d36aa7bd3f8baeb68b9ff9449fL152-R152) [[2]](diffhunk://#diff-4b2e4ad9443410e032d653cea5b9ba0813e6670b84a28a0c49b0ba3aa0e7caa2L72-R72)

**Backend dependency and API usage fixes:**

* Changed the dependency for retrieving the current user in the study plan API from `require_subscription` to `get_current_user`, making the endpoint accessible to all authenticated users, not just subscribers. (`backend/app/routers/study_plan.py`) [[1]](diffhunk://#diff-051c72e2a9c41cec4c08d7a8cb94dadbdd60e07f80d3874f8c4c6d26544fcbdbL9-R9) [[2]](diffhunk://#diff-051c72e2a9c41cec4c08d7a8cb94dadbdd60e07f80d3874f8c4c6d26544fcbdbL31-R31)
* Updated the home page server-side fetch logic to use the `BACKEND_URL` environment variable directly, avoiding issues with Next.js proxy rewrites during SSR. (`frontend/src/app/page.tsx`)