### PR TITLE
feature: deploy to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-05-10
+
+### Fixed
+- Stripe webhook handler: replaced `.get()` calls with `getattr()` on `StripeObject` instances, required since SDK v15.0.0 where `StripeObject` no longer inherits from `dict`
+- `current_period_end` now read from `SubscriptionItem` (via `sub.items.data[0].current_period_end`) in addition to the subscription root, as the field moved to `SubscriptionItem` in Stripe API v2025-03-31 (SDK v12+); both locations are tried for forward and backward compatibility
+- Added `_subscription_period_end()` helper used by both `_handle_checkout_completed` and `_handle_subscription_updated` handlers
+- Separated `STRIPE_BASE_URL` from `APP_BASE_URL` so Stripe redirect URLs can point to a different domain than email links
+
 ## [1.4.0] - 2026-05-10
 
 ### Added

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -152,6 +152,24 @@ async def stripe_webhook(
 
 # ── Event handlers ───────────────────────────────────────────────────────────
 
+def _subscription_period_end(sub: object) -> datetime | None:
+    """Extract current_period_end from a Stripe Subscription object.
+
+    In Stripe API >=2025-03-31 (SDK v12+), current_period_end moved from the
+    Subscription root to each SubscriptionItem. We try both locations.
+    """
+    period_end = getattr(sub, "current_period_end", None)
+    if period_end is None:
+        items = getattr(sub, "items", None)
+        if items is not None:
+            data = getattr(items, "data", None) or []
+            if data:
+                period_end = getattr(data[0], "current_period_end", None)
+    if period_end is not None:
+        return datetime.utcfromtimestamp(int(period_end))
+    return None
+
+
 async def _get_user_by_customer_id(db: AsyncSession, customer_id: str) -> User | None:
     result = await db.execute(
         select(User).where(User.stripe_customer_id == customer_id)
@@ -159,17 +177,17 @@ async def _get_user_by_customer_id(db: AsyncSession, customer_id: str) -> User |
     return result.scalar_one_or_none()
 
 
-async def _handle_checkout_completed(db: AsyncSession, session: dict) -> None:
-    customer_id: str | None = session.get("customer")
-    subscription_id: str | None = session.get("subscription")
+async def _handle_checkout_completed(db: AsyncSession, session: object) -> None:
+    customer_id: str | None = getattr(session, "customer", None)
+    subscription_id: str | None = getattr(session, "subscription", None)
     if not customer_id:
         return
 
     user = await _get_user_by_customer_id(db, customer_id)
     if not user:
         # Try to link by metadata (customer may have been created before storing the ID)
-        metadata: dict = session.get("metadata") or {}
-        user_id_str: str | None = metadata.get("user_id")
+        metadata = getattr(session, "metadata", None) or {}
+        user_id_str: str | None = getattr(metadata, "user_id", None) or (metadata.get("user_id") if isinstance(metadata, dict) else None)
         if user_id_str:
             user = await db.get(User, int(user_id_str))
             if user:
@@ -187,10 +205,8 @@ async def _handle_checkout_completed(db: AsyncSession, session: dict) -> None:
     if subscription_id:
         try:
             sub = stripe.Subscription.retrieve(subscription_id)
-            status = sub.status  # "trialing" | "active"
-            period_end = sub.get("current_period_end")
-            if period_end:
-                ends_at = datetime.utcfromtimestamp(period_end)
+            status = getattr(sub, "status", "trialing")  # "trialing" | "active"
+            ends_at = _subscription_period_end(sub)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "[billing] Could not retrieve subscription %s: %s", subscription_id, exc
@@ -204,8 +220,8 @@ async def _handle_checkout_completed(db: AsyncSession, session: dict) -> None:
     )
 
 
-async def _handle_subscription_updated(db: AsyncSession, subscription: dict) -> None:
-    customer_id: str | None = subscription.get("customer")
+async def _handle_subscription_updated(db: AsyncSession, subscription: object) -> None:
+    customer_id: str | None = getattr(subscription, "customer", None)
     if not customer_id:
         return
 
@@ -213,10 +229,10 @@ async def _handle_subscription_updated(db: AsyncSession, subscription: dict) -> 
     if not user:
         return
 
-    user.subscription_status = subscription.get("status", user.subscription_status)
-    period_end = subscription.get("current_period_end")
-    if period_end:
-        user.subscription_ends_at = datetime.utcfromtimestamp(period_end)
+    user.subscription_status = getattr(subscription, "status", user.subscription_status)
+    ends_at = _subscription_period_end(subscription)
+    if ends_at is not None:
+        user.subscription_ends_at = ends_at
 
     await db.commit()
     logger.info(
@@ -224,8 +240,8 @@ async def _handle_subscription_updated(db: AsyncSession, subscription: dict) -> 
     )
 
 
-async def _handle_subscription_deleted(db: AsyncSession, subscription: dict) -> None:
-    customer_id: str | None = subscription.get("customer")
+async def _handle_subscription_deleted(db: AsyncSession, subscription: object) -> None:
+    customer_id: str | None = getattr(subscription, "customer", None)
     if not customer_id:
         return
 
@@ -238,8 +254,8 @@ async def _handle_subscription_deleted(db: AsyncSession, subscription: dict) -> 
     logger.info("[billing] User %s subscription canceled", user.id)
 
 
-async def _handle_payment_failed(db: AsyncSession, invoice: dict) -> None:
-    customer_id: str | None = invoice.get("customer")
+async def _handle_payment_failed(db: AsyncSession, invoice: object) -> None:
+    customer_id: str | None = getattr(invoice, "customer", None)
     if not customer_id:
         return
 

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -31,6 +31,18 @@ def _stripe_client() -> None:
     stripe.api_key = settings.STRIPE_SECRET_KEY
 
 
+def _sget(obj: object, key: str, default=None):
+    """Get a field from a Stripe event object or a plain dict (test mocks).
+
+    In production, Stripe SDK v15+ returns StripeObject instances that no longer
+    inherit from dict — use getattr(). In tests, construct_event is mocked to
+    return plain Python dicts — use .get(). This helper handles both.
+    """
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
 # ── Request schemas ──────────────────────────────────────────────────────────
 
 class CheckoutRequest(BaseModel):
@@ -157,14 +169,16 @@ def _subscription_period_end(sub: object) -> datetime | None:
 
     In Stripe API >=2025-03-31 (SDK v12+), current_period_end moved from the
     Subscription root to each SubscriptionItem. We try both locations.
+    Uses _sget so it works with both StripeObject (production) and plain dicts
+    (test mocks).
     """
-    period_end = getattr(sub, "current_period_end", None)
+    period_end = _sget(sub, "current_period_end")
     if period_end is None:
-        items = getattr(sub, "items", None)
+        items = _sget(sub, "items")
         if items is not None:
-            data = getattr(items, "data", None) or []
+            data = _sget(items, "data") or []
             if data:
-                period_end = getattr(data[0], "current_period_end", None)
+                period_end = _sget(data[0], "current_period_end")
     if period_end is not None:
         return datetime.utcfromtimestamp(int(period_end))
     return None
@@ -178,16 +192,16 @@ async def _get_user_by_customer_id(db: AsyncSession, customer_id: str) -> User |
 
 
 async def _handle_checkout_completed(db: AsyncSession, session: object) -> None:
-    customer_id: str | None = getattr(session, "customer", None)
-    subscription_id: str | None = getattr(session, "subscription", None)
+    customer_id: str | None = _sget(session, "customer")
+    subscription_id: str | None = _sget(session, "subscription")
     if not customer_id:
         return
 
     user = await _get_user_by_customer_id(db, customer_id)
     if not user:
         # Try to link by metadata (customer may have been created before storing the ID)
-        metadata = getattr(session, "metadata", None) or {}
-        user_id_str: str | None = getattr(metadata, "user_id", None) or (metadata.get("user_id") if isinstance(metadata, dict) else None)
+        metadata = _sget(session, "metadata") or {}
+        user_id_str: str | None = _sget(metadata, "user_id")
         if user_id_str:
             user = await db.get(User, int(user_id_str))
             if user:
@@ -221,7 +235,7 @@ async def _handle_checkout_completed(db: AsyncSession, session: object) -> None:
 
 
 async def _handle_subscription_updated(db: AsyncSession, subscription: object) -> None:
-    customer_id: str | None = getattr(subscription, "customer", None)
+    customer_id: str | None = _sget(subscription, "customer")
     if not customer_id:
         return
 
@@ -229,7 +243,7 @@ async def _handle_subscription_updated(db: AsyncSession, subscription: object) -
     if not user:
         return
 
-    user.subscription_status = getattr(subscription, "status", user.subscription_status)
+    user.subscription_status = _sget(subscription, "status") or user.subscription_status
     ends_at = _subscription_period_end(subscription)
     if ends_at is not None:
         user.subscription_ends_at = ends_at
@@ -241,7 +255,7 @@ async def _handle_subscription_updated(db: AsyncSession, subscription: object) -
 
 
 async def _handle_subscription_deleted(db: AsyncSession, subscription: object) -> None:
-    customer_id: str | None = getattr(subscription, "customer", None)
+    customer_id: str | None = _sget(subscription, "customer")
     if not customer_id:
         return
 
@@ -255,7 +269,7 @@ async def _handle_subscription_deleted(db: AsyncSession, subscription: object) -
 
 
 async def _handle_payment_failed(db: AsyncSession, invoice: object) -> None:
-    customer_id: str | None = getattr(invoice, "customer", None)
+    customer_id: str | None = _sget(invoice, "customer")
     if not customer_id:
         return
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       STRIPE_PRICE_MONTHLY: ${STRIPE_PRICE_MONTHLY:-}
       STRIPE_PRICE_YEARLY: ${STRIPE_PRICE_YEARLY:-}
       STRIPE_TRIAL_DAYS: ${STRIPE_TRIAL_DAYS:-7}
+      STRIPE_BASE_URL: ${STRIPE_BASE_URL:-http://localhost:3000}
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -238,7 +238,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.0</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.1</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -357,7 +357,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.0</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.1</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.4.0**
+**1.4.1**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request updates the billing backend to support Stripe SDK v15+ and Stripe API v2025-03-31, ensuring compatibility with recent changes in Stripe's data structures. It introduces a helper to safely extract fields from both Stripe SDK objects and test mocks, updates how subscription period end dates are read, and separates Stripe and app base URLs for more flexible deployments. The frontend and documentation are also updated for the new version.

**Backend compatibility and Stripe integration:**

* Replaced all direct `.get()` calls on Stripe objects with a new `_sget()` helper, which uses `getattr()` for Stripe SDK objects (since v15 they no longer inherit from `dict`) and `.get()` for test mocks, ensuring compatibility in both production and tests. [[1]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bR34-R45) [[2]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bR167-R204) [[3]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bL190-R223) [[4]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bL207-R258) [[5]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bL241-R272)
* Added `_subscription_period_end()` helper to extract the `current_period_end` field from either the subscription root or the first subscription item, handling Stripe API changes in v2025-03-31 (SDK v12+), and updated all relevant webhook handlers to use it. [[1]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bR167-R204) [[2]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bL190-R223) [[3]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bL207-R258)
* Separated `STRIPE_BASE_URL` from `APP_BASE_URL` in configuration, allowing Stripe redirect URLs to use a different domain than email links; updated `docker-compose.yml` accordingly.

**Documentation and versioning:**

* Updated `CHANGELOG.md` and `specs/version.md` for version 1.4.1, documenting the compatibility fixes and new helper functions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R15) [[2]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3)
* Updated frontend version display in `AppLayout` to 1.4.1. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L241-R241) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L360-R360)