### PR TITLE
feature: stripe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-05-10
+
+### Fixed
+- Admin users list: subscription status tags (`active`, `trial`, `past due`) now use i18n keys via `tBilling` instead of hardcoded English strings
+- Stripe webhook handlers: replaced `getattr()` with `_sget()` helper that handles both `StripeObject` (production, SDK v15+) and plain dicts (test mocks); fixes 4 failing CI tests
+
+### Changed
+- Landing page pricing section extracted to `PricingSection` client component; section is now hidden for users who already have an active or trialing subscription
+- Restored `pricingLabel` heading above `pricingTitle` in the pricing section
+
 ## [1.4.1] - 2026-05-10
 
 ### Fixed

--- a/frontend/src/app/(app)/admin/users/page.tsx
+++ b/frontend/src/app/(app)/admin/users/page.tsx
@@ -22,6 +22,7 @@ const LANGUAGES = ['es', 'fr', 'pt', 'de', 'it', 'pl', 'nl', 'ro', 'ru'] as cons
 
 export default function AdminUsersPage() {
   const t = useTranslations('admin')
+  const tBilling = useTranslations('billing')
   const tLang = useTranslations('languages')
   const [users, setUsers] = useState<AdminUserItem[]>([])
   const [total, setTotal] = useState(0)
@@ -272,13 +273,13 @@ export default function AdminUsersPage() {
                       <span className="font-mono text-fl-hint tracking-widest uppercase border border-fl-error/30 text-fl-error-fg px-2 py-0.5">{t('inactive')}</span>
                     )}
                     {u.subscription_status === 'active' && (
-                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-green-500/40 text-green-400 px-2 py-0.5">active</span>
+                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-green-500/40 text-green-400 px-2 py-0.5">{tBilling('statusActive')}</span>
                     )}
                     {u.subscription_status === 'trialing' && (
-                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-blue-500/40 text-blue-400 px-2 py-0.5">trial</span>
+                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-blue-500/40 text-blue-400 px-2 py-0.5">{tBilling('statusTrialing')}</span>
                     )}
                     {u.subscription_status === 'past_due' && (
-                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-yellow-500/40 text-yellow-400 px-2 py-0.5">past due</span>
+                      <span className="font-mono text-fl-hint tracking-widest uppercase border border-yellow-500/40 text-yellow-400 px-2 py-0.5">{tBilling('statusPastDue')}</span>
                     )}
                   </div>
                   <p className="font-mono text-fl-label text-fl-muted-2 break-all">

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -238,7 +238,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.1</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.2</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -357,7 +357,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.1</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.2</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,13 +2,13 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { cookies } from 'next/headers'
 import { getTranslations } from 'next-intl/server'
+import PricingSection from '@/components/billing/PricingSection'
 
 export default async function Home() {
   const cookieStore = await cookies()
   const hasSession = cookieStore.has('refresh_token')
   const t = await getTranslations('landing')
   const tCommon = await getTranslations('common')
-  const tBilling = await getTranslations('billing')
 
   // Fetch Stripe config server-side to conditionally show pricing section.
   // Use BACKEND_URL directly to avoid the Next.js rewrite proxy chain,
@@ -94,74 +94,8 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* Pricing — only shown when Stripe is enabled */}
-      {stripeEnabled && (
-        <section className="max-w-4xl mx-auto px-6 pb-24 w-full">
-          <div className="text-center mb-10">
-            <h2 className="font-mono text-base font-bold text-fl-fg mb-2">
-              {tBilling('pricingTitle')}
-            </h2>
-            <p className="font-mono text-xs text-fl-muted-1 tracking-widest">
-              {tBilling('pricingDesc', { days: trialDays })}
-            </p>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Monthly plan */}
-            <div className="border border-fl-border bg-fl-surface p-6 flex flex-col gap-4">
-              <div className="flex items-center gap-2 pb-3 border-b border-fl-border">
-                <span className="text-fl-muted-2 text-sm">◎</span>
-                <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-                  {tBilling('planMonthlyName')}
-                </span>
-              </div>
-              <p className="font-mono text-xl font-bold text-fl-fg">
-                14.95<span className="text-sm text-fl-muted-1">€ / {tBilling('month')}</span>
-              </p>
-              <ul className="flex flex-col gap-1.5">
-                {['feature1', 'feature2', 'feature3', 'feature4'].map((k) => (
-                  <li key={k} className="font-mono text-xs text-fl-muted-1 flex items-center gap-2">
-                    <span className="text-fl-accent">✓</span> {tBilling(`planFeature.${k}`)}
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            {/* Yearly plan */}
-            <div className="border border-fl-accent/30 bg-fl-surface p-6 flex flex-col gap-4">
-              <div className="flex items-center justify-between pb-3 border-b border-fl-border">
-                <div className="flex items-center gap-2">
-                  <span className="text-fl-muted-2 text-sm">▣</span>
-                  <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
-                    {tBilling('planYearlyName')}
-                  </span>
-                </div>
-                <span className="font-mono text-fl-hint text-fl-accent border border-fl-accent/30 px-2 py-0.5 uppercase tracking-widest">
-                  {tBilling('bestValue')}
-                </span>
-              </div>
-              <p className="font-mono text-xl font-bold text-fl-fg">
-                149.50<span className="text-sm text-fl-muted-1">€ / {tBilling('year')}</span>
-              </p>
-              <ul className="flex flex-col gap-1.5">
-                {['feature1', 'feature2', 'feature3', 'feature4', 'feature5'].map((k) => (
-                  <li key={k} className="font-mono text-xs text-fl-muted-1 flex items-center gap-2">
-                    <span className="text-fl-accent">✓</span> {tBilling(`planFeature.${k}`)}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-
-          <div className="mt-8 text-center">
-            <Link
-              href={hasSession ? '/dashboard' : '/register'}
-              className="inline-block font-mono text-xs font-bold tracking-widest uppercase py-3 px-10 bg-fl-accent text-fl-accent-fg hover:bg-fl-accent/90 transition-colors"
-            >
-              — {tBilling('ctaStart', { days: trialDays })}
-            </Link>
-          </div>
-        </section>
-      )}
+      {/* Pricing — only shown when Stripe is enabled and user is not already subscribed */}
+      <PricingSection stripeEnabled={stripeEnabled} trialDays={trialDays} hasSession={hasSession} />
 
       {/* Footer */}
       <footer className="border-t border-fl-border py-6 px-6">

--- a/frontend/src/components/billing/PricingSection.tsx
+++ b/frontend/src/components/billing/PricingSection.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import Link from 'next/link'
+import { useTranslations } from 'next-intl'
+import { useAuthStore, isSubscribed } from '@/store/auth'
+import { useConfigStore } from '@/store/config'
+
+interface PricingSectionProps {
+  /** Whether Stripe is enabled (from server-side config fetch). */
+  stripeEnabled: boolean
+  trialDays: number
+  /** True if the browser has a refresh_token cookie (user may be logged in). */
+  hasSession: boolean
+}
+
+export default function PricingSection({ stripeEnabled, trialDays, hasSession }: PricingSectionProps) {
+  const tBilling = useTranslations('billing')
+  const user = useAuthStore((s) => s.user)
+  // Use client-side config when available; fall back to server-side prop.
+  const stripeEnabledClient = useConfigStore((s) => s.stripeEnabled)
+  const resolvedStripeEnabled = stripeEnabledClient ?? stripeEnabled
+
+  if (!resolvedStripeEnabled) return null
+
+  // Hide for subscribed users. If the user has a session but the store hasn't
+  // hydrated yet (user === null), also hide to avoid a flash for subscribed users.
+  if (hasSession && (user === null || isSubscribed(user, true))) return null
+
+  return (
+    <section className="max-w-4xl mx-auto px-6 pb-24 w-full">
+      <div className="text-center mb-10">
+        <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase mb-4 block">
+          {tBilling('pricingLabel')}
+        </span>
+        <h2 className="font-mono text-base font-bold text-fl-fg mb-2">
+          {tBilling('pricingTitle')}
+        </h2>
+        <p className="font-mono text-xs text-fl-muted-1 tracking-widest">
+          {tBilling('pricingDesc', { days: trialDays })}
+        </p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Monthly plan */}
+        <div className="border border-fl-border bg-fl-surface p-6 flex flex-col gap-4">
+          <div className="flex items-center gap-2 pb-3 border-b border-fl-border">
+            <span className="text-fl-muted-2 text-sm">◎</span>
+            <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
+              {tBilling('planMonthlyName')}
+            </span>
+          </div>
+          <p className="font-mono text-xl font-bold text-fl-fg">
+            14.95<span className="text-sm text-fl-muted-1"> € / {tBilling('month')}</span>
+          </p>
+          <ul className="flex flex-col gap-1.5">
+            {['feature1', 'feature2', 'feature3', 'feature4'].map((k) => (
+              <li key={k} className="font-mono text-xs text-fl-muted-1 flex items-center gap-2">
+                <span className="text-fl-accent">✓</span> {tBilling(`planFeature.${k}`)}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Yearly plan */}
+        <div className="border border-fl-accent/30 bg-fl-surface p-6 flex flex-col gap-4">
+          <div className="flex items-center justify-between pb-3 border-b border-fl-border">
+            <div className="flex items-center gap-2">
+              <span className="text-fl-muted-2 text-sm">▣</span>
+              <span className="font-mono text-fl-label tracking-widest text-fl-muted-2 uppercase">
+                {tBilling('planYearlyName')}
+              </span>
+            </div>
+            <span className="font-mono text-fl-hint text-fl-accent border border-fl-accent/30 px-2 py-0.5 uppercase tracking-widest">
+              {tBilling('bestValue')}
+            </span>
+          </div>
+          <p className="font-mono text-xl font-bold text-fl-fg">
+            149.50<span className="text-sm text-fl-muted-1"> € / {tBilling('year')}</span>
+          </p>
+          <ul className="flex flex-col gap-1.5">
+            {['feature1', 'feature2', 'feature3', 'feature4', 'feature5'].map((k) => (
+              <li key={k} className="font-mono text-xs text-fl-muted-1 flex items-center gap-2">
+                <span className="text-fl-accent">✓</span> {tBilling(`planFeature.${k}`)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="mt-8 text-center">
+        <Link
+          href={hasSession ? '/dashboard' : '/register'}
+          className="inline-block font-mono text-xs font-bold tracking-widest uppercase py-3 px-10 bg-fl-accent text-fl-accent-fg hover:bg-fl-accent/90 transition-colors"
+        >
+          — {tBilling('ctaStart', { days: trialDays })}
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.4.1**
+**1.4.2**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request releases version 1.4.2, focusing on improvements to the admin users page, the landing page pricing section, and Stripe integration. The most notable changes include internationalization fixes for subscription status tags, a refactor of the pricing section into a reusable component, and improved logic to hide pricing for already subscribed users. Additionally, Stripe webhook handling is made more robust, and the version is bumped throughout the project.

**Admin and Billing UI improvements:**
* The admin users list now uses i18n keys (`tBilling`) for subscription status tags (`active`, `trial`, `past due`) instead of hardcoded English strings, ensuring proper localization. [[1]](diffhunk://#diff-284f6e50bfbe196253a33dc10dc57918da86a764e38c65f39b367547ae27a594R25) [[2]](diffhunk://#diff-284f6e50bfbe196253a33dc10dc57918da86a764e38c65f39b367547ae27a594L275-R282)
* The landing page pricing section is extracted into a new `PricingSection` client component, which is only shown if Stripe is enabled and the user does not already have an active or trialing subscription. The pricing label heading above the pricing title is also restored for better clarity. [[1]](diffhunk://#diff-bc32312b6e0185cbc840269d0632c2a90ed907d36aa7bd3f8baeb68b9ff9449fR5-L11) [[2]](diffhunk://#diff-bc32312b6e0185cbc840269d0632c2a90ed907d36aa7bd3f8baeb68b9ff9449fL97-R98) [[3]](diffhunk://#diff-3f8940bbc513a928191a033bf875fad420f24c3f08bbacdc5ea29c28f6d7f9dcR1-R99)

**Stripe integration and backend robustness:**
* Stripe webhook handlers now use a new `_sget()` helper instead of `getattr()`, allowing compatibility with both `StripeObject` (SDK v15+) and plain dicts (test mocks), which fixes four failing CI tests.

**Version bump and documentation:**
* The project version is bumped to 1.4.2 in all relevant files (`CHANGELOG.md`, `specs/version.md`, and UI footers). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R17) [[2]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3) [[3]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L241-R241) [[4]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L360-R360)