### PR TITLE
feature: deploy to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2026-05-10
+
+### Fixed
+- Landing page: pricing section now shows immediately for unauthenticated users (no loading state); authenticated users see a full-screen loading overlay (backdrop blur, same pattern as onboarding tour) while subscription status is verified, avoiding layout shifts or premature reveals
+- Middleware: inverted auth logic from public-routes whitelist to protected-routes list; unknown URLs now reach the Next.js 404 handler instead of being redirected to `/login`
+
 ## [1.4.3] - 2026-05-10
 
 ### Added

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -238,7 +238,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.3</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.4</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -357,7 +357,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.3</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.4</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/components/billing/PricingSection.tsx
+++ b/frontend/src/components/billing/PricingSection.tsx
@@ -12,14 +12,14 @@ interface PricingSectionProps {
 
 export default function PricingSection({ stripeEnabled, trialDays, hasSession }: PricingSectionProps) {
   const tBilling = useTranslations('billing')
-  // null = not yet determined, true = subscribed (hide), false = not subscribed (show)
+  const tCommon = useTranslations('common')
+  // null = checking (only when hasSession=true), true = subscribed (hide pricing), false = show pricing
   const [subscribed, setSubscribed] = useState<boolean | null>(hasSession ? null : false)
 
   useEffect(() => {
     if (!hasSession) return
     async function checkSubscription() {
       try {
-        // Refresh to get an access token (same pattern as app layout)
         const refreshRes = await fetch('/api/auth/refresh', {
           method: 'POST',
           credentials: 'include',
@@ -43,8 +43,19 @@ export default function PricingSection({ stripeEnabled, trialDays, hasSession }:
   }, [hasSession])
 
   if (!stripeEnabled) return null
-  // Still checking — render nothing to avoid layout shift
-  if (subscribed === null) return null
+
+  // Loading state: show full-screen overlay while verifying subscription
+  if (subscribed === null) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <div className="absolute inset-0 bg-fl-bg/80 backdrop-blur-sm" />
+        <span className="relative font-mono text-xs tracking-widest text-fl-muted-2 uppercase animate-pulse">
+          {tCommon('loading')}
+        </span>
+      </div>
+    )
+  }
+
   if (subscribed) return null
 
   return (

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,8 +1,26 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-const PUBLIC_ROUTES = ['/login', '/register', '/terms', '/privacy', '/forgot-password', '/reset-password', '/verify-email']
-const PUBLIC_EXACT = ['/']
+// Routes that require authentication — anything else passes through so unknown
+// URLs reach Next.js's 404 handler instead of being redirected to /login.
+const PROTECTED_ROUTES = [
+  '/admin',
+  '/assessment',
+  '/billing',
+  '/chat',
+  '/conversation',
+  '/dashboard',
+  '/faq',
+  '/flashcards',
+  '/grammar',
+  '/lesson',
+  '/onboarding',
+  '/phrasebook',
+  '/plan',
+  '/progress',
+  '/settings',
+  '/vocabulary',
+]
 const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'pt', 'de', 'it', 'pl', 'nl', 'ro', 'ru'] as const
 type Locale = (typeof SUPPORTED_LOCALES)[number]
 
@@ -33,11 +51,9 @@ export function middleware(req: NextRequest) {
   const locale = detectLocale(req)
 
   const hasRefreshToken = req.cookies.has('refresh_token')
-  const isPublic =
-    PUBLIC_EXACT.includes(req.nextUrl.pathname) ||
-    PUBLIC_ROUTES.some((r) => req.nextUrl.pathname.startsWith(r))
+  const isProtected = PROTECTED_ROUTES.some((r) => req.nextUrl.pathname.startsWith(r))
 
-  if (!hasRefreshToken && !isPublic) {
+  if (!hasRefreshToken && isProtected) {
     const response = NextResponse.redirect(new URL('/login', req.url))
     if (!req.cookies.has('NEXT_LOCALE')) {
       response.cookies.set('NEXT_LOCALE', locale, {

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.4.3**
+**1.4.4**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request updates the application to version 1.4.4 and focuses on improving the user experience on the landing page, as well as refining authentication logic in the middleware. The most significant changes are the immediate display of the pricing section for unauthenticated users, a new loading overlay for authenticated users while subscription status is checked, and a switch from a public-routes whitelist to a protected-routes list in the middleware, allowing unknown URLs to reach the Next.js 404 handler.

**Landing Page & Pricing Section Improvements:**
- The pricing section now displays immediately for unauthenticated users, removing any loading state. Authenticated users see a full-screen loading overlay (with backdrop blur) while their subscription status is verified, preventing layout shifts or premature content reveals. [[1]](diffhunk://#diff-3f8940bbc513a928191a033bf875fad420f24c3f08bbacdc5ea29c28f6d7f9dcL15-L22) [[2]](diffhunk://#diff-3f8940bbc513a928191a033bf875fad420f24c3f08bbacdc5ea29c28f6d7f9dcL46-R58) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13)

**Authentication & Routing Middleware:**
- The middleware now uses a protected-routes list instead of a public-routes whitelist. Only specified routes require authentication; unknown URLs now correctly reach the Next.js 404 handler instead of being redirected to `/login`. [[1]](diffhunk://#diff-c97d84b7bce6d5239ff87ac5694ad83d8aee62fcb23fbf6870be5bd08a5222acL4-R23) [[2]](diffhunk://#diff-c97d84b7bce6d5239ff87ac5694ad83d8aee62fcb23fbf6870be5bd08a5222acL36-R56) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13)

**Version Bump:**
- Application version updated from 1.4.3 to 1.4.4 in the UI, changelog, and version spec files. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L241-R241) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L360-R360) [[3]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13)