### PR TITLE
feature: readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.6] - 2026-05-11
+
+### Fixed
+- `monthly_tokens_limit` server-default in PostgreSQL corrected from `0` (unlimited) to `1000000`, aligning it with the ORM default; new migration `0017_fix_monthly_tokens_server_default`.
+
+### Changed
+- README: added **Hosted service** section with link to [freelingo.app](https://freelingo.app) to make the managed subscription option visible.
+
 ## [1.4.5] - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin can manually override `subscription_status` and `subscription_ends_at` via `PATCH /api/admin/users/{id}`
 - `store/config.ts` (frontend): fetches `/api/config` on app load, exposes `stripeEnabled` and `stripeTrialDays`
 - `store/auth.ts`: `User` type extended with `subscription_status` and `subscription_ends_at`; exported `isSubscribed()` helper
-- `PaywallBanner` and `PaywallGate` components: paywall overlay with monthly (14.95€) and yearly (119€) plan buttons; renders nothing when Stripe is disabled
+- `PaywallBanner` and `PaywallGate` components: paywall overlay with monthly (14.95€) and yearly (149.50€) plan buttons; renders nothing when Stripe is disabled
 - `PaywallGate` applied to six frontend pages: `/chat`, `/conversation`, `/flashcards`, `/dashboard`, `/lesson/[id]`, `/assessment/level-test`
 - Settings page: subscription status badge, next billing date, "Manage subscription" portal link, "Subscribe" CTA — section hidden when Stripe is disabled
 - Landing page: pricing section (two plan cards) conditionally rendered when `STRIPE_ENABLED=true`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ freelingo/
 | 4     | Multi-language support | ✅ Complete         |
 | 5     | Stripe subscriptions   | ✅ Complete         |
 
+## Hosted service
+
+> **Don't want to manage your own server?**  
+> FreeLingo is available as a fully managed hosted service at **[freelingo.app](https://freelingo.app)**.
+
+Sign up, choose a subscription plan, and start learning immediately — no Docker, no GPU, no maintenance required.
+The hosted instance is operated by the FreeLingo team and always runs the latest stable version.
+
+Self-hosting remains free and open source under the AGPL-3.0 licence. The hosted service exists for users who prefer a managed experience.
+
+---
+
 ## Quick start
 
 ### Option A — Git clone + Docker Compose

--- a/backend/alembic/versions/0017_fix_monthly_tokens_server_default.py
+++ b/backend/alembic/versions/0017_fix_monthly_tokens_server_default.py
@@ -1,0 +1,35 @@
+"""Fix monthly_tokens_limit server default to 1000000 (was 0)
+
+Revision ID: 0017_fix_monthly_tokens_server_default
+Revises: 0016_stripe_subscription
+Create Date: 2026-05-11
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0017_fix_monthly_tokens_server_default"
+down_revision: Union[str, None] = "0016_stripe_subscription"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "users",
+        "monthly_tokens_limit",
+        existing_type=sa.Integer(),
+        server_default="1000000",
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "users",
+        "monthly_tokens_limit",
+        existing_type=sa.Integer(),
+        server_default="0",
+        existing_nullable=False,
+    )

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -238,7 +238,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.5</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.6</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -357,7 +357,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.5</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.6</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/specs/phase-5-stripe-subscriptions.instructions.md
+++ b/specs/phase-5-stripe-subscriptions.instructions.md
@@ -16,7 +16,7 @@ Introduce an optional, fully configurable subscription layer backed by Stripe. W
 | Plan | Price | Billing | Trial |
 |------|-------|---------|-------|
 | Monthly | 14.95 €/month | Monthly recurring | 7 days free (card required) |
-| Yearly | 119 €/year (≈ 9.92 €/month, 34% off) | Annual recurring | 7 days free (card required) |
+| Yearly | 149.50 €/year (≈ 12.46 €/month, 2 months free) | Annual recurring | 7 days free (card required) |
 
 ### Quotas applied on subscription activation
 | Quota field | Value |
@@ -252,11 +252,11 @@ function isSubscribed(user: User, stripeEnabled: boolean): boolean {
 ### 4.3 `PaywallBanner` component
 Shown in place of protected page content when `stripeEnabled && !isSubscribed`.
 
-- Headline: "Activa tu prueba gratuita de 7 días" (i18n)
+- Headline: "Start your 7-day free trial" (i18n)
 - Subtext: brief list of what's included
-- Two buttons: "Mensual — 14.95€/mes" and "Anual — 119€/año (ahorra 34%)"
+- Two buttons: "Monthly — €14.95/month" and "Yearly — €149.50/year (2 months free)"
 - Each button calls `POST /api/billing/checkout` with the corresponding plan, then `router.push(url)`
-- Small link "¿Ya eres suscriptor? Refresca tu sesión" (calls `/api/auth/refresh` to re-sync status)
+- Small link "Already a subscriber? Refresh your session" (calls `/api/auth/refresh` to re-sync status)
 
 ### 4.4 Apply paywall to protected pages
 In each protected page component, check `stripeEnabled && !isSubscribed(user, stripeEnabled)`:
@@ -271,10 +271,10 @@ The rest of the page (sidebar, header) remains visible — only the main content
 
 ### 4.5 Billing section in Settings/Profile
 Only rendered when `stripeEnabled`. Shows:
-- Current plan: "Mensual" / "Anual" / "Período de prueba" / "Sin suscripción"
+- Current plan: "Monthly" / "Yearly" / "Trial" / "No subscription"
 - Status badge: active (green) / trialing (blue) / past_due (amber) / canceled (red)
 - Next billing date (from `subscription_ends_at`)
-- Button "Gestionar suscripción" → `POST /api/billing/portal` → `router.push(url)`
+- Button "Manage subscription" → `POST /api/billing/portal` → `router.push(url)`
 
 ### 4.6 Pricing section in landing page (`/`)
 Only rendered when `stripeEnabled`. Positioned after the features section.
@@ -282,24 +282,24 @@ Only rendered when `stripeEnabled`. Positioned after the features section.
 Layout:
 ```
 ┌─────────────────────────┐  ┌─────────────────────────┐
-│  Mensual                │  │  Anual  ★ Más popular   │
-│  14.95 €/mes            │  │  119 €/año              │
-│                         │  │  9.92 €/mes             │
-│  7 días gratis          │  │  7 días gratis          │
-│                         │  │  Ahorra 34%             │
-│  ✓ 3 sesiones de voz    │  │  ✓ 3 sesiones de voz    │
-│  ✓ 30 min por sesión    │  │  ✓ 30 min por sesión    │
-│  ✓ Chat con tutor IA    │  │  ✓ Chat con tutor IA    │
-│  ✓ Plan personalizado   │  │  ✓ Plan personalizado   │
-│  ✓ Lecciones y          │  │  ✓ Lecciones y          │
+│  Monthly                │  │  Yearly  ★ Best value   │
+│  14.95 €/month          │  │  149.50 €/year          │
+│                         │  │  12.46 €/month          │
+│  7 days free            │  │  7 days free            │
+│                         │  │  2 months free          │
+│  ✓ 3 voice sessions     │  │  ✓ 3 voice sessions     │
+│  ✓ 30 min per session   │  │  ✓ 30 min per session   │
+│  ✓ AI tutor chat        │  │  ✓ AI tutor chat        │
+│  ✓ Personalised plan    │  │  ✓ Personalised plan    │
+│  ✓ Lessons &            │  │  ✓ Lessons &            │
 │    flashcards           │  │    flashcards           │
 │                         │  │                         │
-│  [Empezar gratis]       │  │  [Empezar gratis]       │
+│  [Start for free]       │  │  [Start for free]       │
 └─────────────────────────┘  └─────────────────────────┘
-         Cancela cuando quieras · Sin permanencia
+              Cancel anytime · No commitment
 ```
 
-Clicking "Empezar gratis" redirects to `/login` if not authenticated, or calls `/api/billing/checkout` directly if already logged in.
+Clicking "Start for free" redirects to `/login` if not authenticated, or calls `/api/billing/checkout` directly if already logged in.
 
 ### 4.7 `/billing/success` page
 - Shown after successful Stripe Checkout.

--- a/specs/roadmap.instructions.md
+++ b/specs/roadmap.instructions.md
@@ -191,7 +191,7 @@ This document records what was built and the completion criteria met.
 
 **Plans:**
 - Monthly: 14.95 €/month · 7-day trial (card required)
-- Yearly: 119 €/year (≈ 9.92 €/month, 34% off) · 7-day trial (card required)
+- Yearly: 149.50 €/year (≈ 12.46 €/month, 2 months free) · 7-day trial (card required)
 
 **Completion criteria:**
 - [x] `STRIPE_ENABLED=false` → no paywall, no billing UI, all endpoints accessible

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.4.5**
+**1.4.6**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request updates the project to version 1.4.6, correcting the default monthly token limit in the database, updating documentation and UI to reflect new subscription pricing, and adding a section about the hosted service. The most important changes are summarized below:

**Database and Backend Fixes:**
- Added migration `0017_fix_monthly_tokens_server_default.py` to set the PostgreSQL server default for `monthly_tokens_limit` to `1000000` instead of `0`, aligning it with the ORM default.
- Documented this fix in the `CHANGELOG.md` under version 1.4.6.

**Subscription Pricing and Documentation Updates:**
- Updated all references to the yearly subscription price from €119/year to €149.50/year, and adjusted the description to "2 months free" instead of "34% off" in documentation, specs, and UI. [[1]](diffhunk://#diff-94153038ac50239f6c4217cc949ccdf29df14feb46a81497416b1572b16c928aL19-R19) [[2]](diffhunk://#diff-cf1900c54084dac9674e49012a99c2a2a9788522a3160e59e4159d00ca395a13L194-R194) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL71-R79)
- Changed all paywall and billing-related UI copy from Spanish to English, and updated pricing details and plan descriptions for consistency. [[1]](diffhunk://#diff-94153038ac50239f6c4217cc949ccdf29df14feb46a81497416b1572b16c928aL255-R259) [[2]](diffhunk://#diff-94153038ac50239f6c4217cc949ccdf29df14feb46a81497416b1572b16c928aL274-R302)

**Hosted Service Announcement:**
- Added a new "Hosted service" section to the `README.md` with a link to [freelingo.app](https://freelingo.app), making the managed subscription option visible. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R91) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R15)

**Version Bump:**
- Updated version numbers in both the UI (`frontend/src/app/(app)/layout.tsx`) and `specs/version.md` from 1.4.5 to 1.4.6. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L241-R241) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L360-R360) [[3]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3)