### PR TITLE
feature: deploy to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.7] - 2026-05-11
+
+### Fixed
+- Alembic migration `0017` revision ID shortened from 38 to 23 characters to fit the `varchar(32)` limit of the `alembic_version` table; migration file renamed to `0017_fix_tokens_default.py`.
+- Stripe Checkout Session now passes `allow_promotion_codes=True` so the promo code field is visible to users.
+
 ## [1.4.6] - 2026-05-11
 
 ### Fixed

--- a/backend/alembic/versions/0017_fix_tokens_default.py
+++ b/backend/alembic/versions/0017_fix_tokens_default.py
@@ -1,6 +1,6 @@
 """Fix monthly_tokens_limit server default to 1000000 (was 0)
 
-Revision ID: 0017_fix_monthly_tokens_server_default
+Revision ID: 0017_fix_tokens_default
 Revises: 0016_stripe_subscription
 Create Date: 2026-05-11
 """
@@ -9,7 +9,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0017_fix_monthly_tokens_server_default"
+revision: str = "0017_fix_tokens_default"
 down_revision: Union[str, None] = "0016_stripe_subscription"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -92,6 +92,7 @@ async def create_checkout_session(
         customer=customer_id,
         line_items=[{"price": price_id, "quantity": 1}],
         mode="subscription",
+        allow_promotion_codes=True,
         subscription_data=subscription_data,
         success_url=f"{settings.STRIPE_BASE_URL}/billing/success",
         cancel_url=f"{settings.STRIPE_BASE_URL}/billing/canceled",

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -238,7 +238,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.6</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.7</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -357,7 +357,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.6</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.4.7</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.4.6**
+**1.4.7**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request focuses on two main fixes: addressing a database migration issue related to Alembic revision IDs and improving the Stripe Checkout experience by enabling promotion codes. It also updates version references throughout the project to `v1.4.7`.

**Database migration fix:**

* Shortened the Alembic migration `0017` revision ID from 38 to 23 characters to comply with the `varchar(32)` limit in the `alembic_version` table, and renamed the migration file to `0017_fix_tokens_default.py`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-5c21fd72426ff339da48b40dd03efbaca64831ac2f7a8715b2c823adabca587dL3-R3) [[3]](diffhunk://#diff-5c21fd72426ff339da48b40dd03efbaca64831ac2f7a8715b2c823adabca587dL12-R12)

**Billing and Stripe integration:**

* Updated the Stripe Checkout Session to pass `allow_promotion_codes=True`, making the promo code field visible to users during checkout. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-f670fb62c1bb7a23e192aeb30f250ada394add1a73a11555522c37f16107089bR95)

**Version bump:**

* Updated all version references in the frontend and documentation from `v1.4.6` to `v1.4.7`. [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L241-R241) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L360-R360) [[3]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3)