### PR TITLE
feature: fix for develop workflow

### DIFF
--- a/.github/workflows/docker-publish-develop.yml
+++ b/.github/workflows/docker-publish-develop.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: develop
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for Docker publishing. The workflow now explicitly checks out the `develop` branch when running.

* Workflow improvement:
  * [`.github/workflows/docker-publish-develop.yml`](diffhunk://#diff-c72380985345e2271e52788a367987f558d34626f611df7ae91b8fe1042d98edR24-R25): Updated the checkout step to use the `develop` branch explicitly.