### PR TITLE
feature: test

### DIFF
--- a/backend/tests/test_admin_extra.py
+++ b/backend/tests/test_admin_extra.py
@@ -1,0 +1,145 @@
+"""Extra admin tests: GET /users/{id}/stats and GET /users/{id}/quota."""
+from __future__ import annotations
+
+import pytest
+
+
+# ── GET /api/admin/users/{id}/stats ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_admin_user_stats_zero_for_new_user(client, admin_user, test_user):
+    """Stats endpoint returns all-zero values for a brand-new user."""
+    _, admin_headers = admin_user
+    user, _ = test_user
+
+    response = await client.get(
+        f"/api/admin/users/{user.id}/stats",
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user_id"] == user.id
+    assert data["xp_total"] == 0
+    assert data["lessons_completed"] == 0
+    assert data["chat_messages_sent"] == 0
+    assert data["tokens_total"] == 0
+    assert data["current_cefr"] is None
+
+
+@pytest.mark.asyncio
+async def test_admin_user_stats_reflects_completed_lesson(client, admin_user, test_user, db_session):
+    """After completing a lesson, lessons_completed increments to 1."""
+    _, admin_headers = admin_user
+    user, _ = test_user
+
+    from app.models.lesson import Lesson
+    from app.models.study_plan import StudyPlan
+
+    plan = StudyPlan(
+        user_id=user.id,
+        cefr_level="B1",
+        goals=["speaking"],
+        duration_weeks=4,
+        days_per_week=4,
+        current_unit="",
+        generated_plan={},
+        is_active=True,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+
+    lesson = Lesson(
+        study_plan_id=plan.id,
+        title="Completed Lesson",
+        lesson_type="grammar",
+        cefr_level="B1",
+        week_number=1,
+        day_number=1,
+        is_completed=True,
+        content={},
+    )
+    db_session.add(lesson)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/admin/users/{user.id}/stats",
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["lessons_completed"] == 1
+    assert data["current_cefr"] == "B1"
+
+
+@pytest.mark.asyncio
+async def test_admin_user_stats_not_found(client, admin_user):
+    """Stats endpoint returns 404 for a non-existent user ID."""
+    _, admin_headers = admin_user
+    response = await client.get("/api/admin/users/99999/stats", headers=admin_headers)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_user_stats_requires_admin(client, test_user):
+    """Regular users cannot access the stats endpoint."""
+    user, headers = test_user
+    response = await client.get(
+        f"/api/admin/users/{user.id}/stats",
+        headers=headers,
+    )
+    assert response.status_code == 403
+
+
+# ── GET /api/admin/users/{id}/quota ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_admin_user_quota_returns_fields(client, admin_user, test_user):
+    """Quota endpoint returns the expected quota structure for the target user."""
+    _, admin_headers = admin_user
+    user, _ = test_user
+
+    response = await client.get(
+        f"/api/admin/users/{user.id}/quota",
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "sessions_this_week" in data
+    assert "sessions_limit" in data
+    assert "minutes_today" in data
+    assert "minutes_limit" in data
+
+
+@pytest.mark.asyncio
+async def test_admin_user_quota_initial_zero(client, admin_user, test_user):
+    """Fresh user has zero usage in all quota counters."""
+    _, admin_headers = admin_user
+    user, _ = test_user
+
+    response = await client.get(
+        f"/api/admin/users/{user.id}/quota",
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["sessions_this_week"] == 0
+    assert data["minutes_today"] == 0
+
+
+@pytest.mark.asyncio
+async def test_admin_user_quota_not_found(client, admin_user):
+    """Quota endpoint returns 404 for a non-existent user ID."""
+    _, admin_headers = admin_user
+    response = await client.get("/api/admin/users/99999/quota", headers=admin_headers)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_user_quota_requires_admin(client, test_user):
+    """Regular users cannot access the quota admin endpoint."""
+    user, headers = test_user
+    response = await client.get(
+        f"/api/admin/users/{user.id}/quota",
+        headers=headers,
+    )
+    assert response.status_code == 403

--- a/backend/tests/test_auth_extra.py
+++ b/backend/tests/test_auth_extra.py
@@ -1,0 +1,135 @@
+"""Extra auth tests: DELETE /api/auth/me, GET /api/auth/quota, blocked email domains."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.config import settings
+
+
+# ── DELETE /api/auth/me ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_delete_me_success(client, test_user, db_session):
+    """A regular user can delete their own account; record is removed from DB."""
+    user, headers = test_user
+    response = await client.delete("/api/auth/me", headers=headers)
+    assert response.status_code == 204
+
+    from app.models.user import User
+    found = await db_session.get(User, user.id)
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_delete_me_requires_auth(client):
+    """DELETE /me without a valid token returns 401."""
+    response = await client.delete(
+        "/api/auth/me",
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_me_admin_forbidden(client, admin_user):
+    """Admin accounts cannot self-delete; endpoint returns 403."""
+    _, headers = admin_user
+    response = await client.delete("/api/auth/me", headers=headers)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_me_clears_refresh_cookie(client, test_user, mock_redis):
+    """After deletion the refresh_token cookie is cleared."""
+    user, headers = test_user
+    # Seed a fake refresh token so the endpoint has something to delete
+    await mock_redis.setex("refresh:faketoken", 86400, str(user.id))
+
+    response = await client.delete(
+        "/api/auth/me",
+        headers=headers,
+        cookies={"refresh_token": "faketoken"},
+    )
+    assert response.status_code == 204
+    # Cookie should be cleared (max_age=0 or absent from Set-Cookie)
+    set_cookie = response.headers.get("set-cookie", "")
+    assert "refresh_token" not in set_cookie or "max-age=0" in set_cookie.lower() or 'expires' in set_cookie.lower()
+
+
+# ── GET /api/auth/quota ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_quota_returns_expected_fields(client, test_user):
+    """GET /quota returns the full quota structure with expected keys."""
+    _, headers = test_user
+    response = await client.get("/api/auth/quota", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert "sessions_this_week" in data
+    assert "sessions_limit" in data
+    assert "sessions_unlimited" in data
+    assert "minutes_today" in data
+    assert "minutes_limit" in data
+    assert "tokens_this_month" in data
+    assert "tokens_monthly_limit" in data
+    assert "tokens_unlimited" in data
+
+
+@pytest.mark.asyncio
+async def test_get_quota_initial_values(client, test_user):
+    """Fresh user has zero usage in all quota counters."""
+    _, headers = test_user
+    response = await client.get("/api/auth/quota", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["sessions_this_week"] == 0
+    assert data["minutes_today"] == 0
+    assert data["tokens_this_month"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_quota_requires_auth(client):
+    """GET /quota without a valid token returns 401."""
+    response = await client.get(
+        "/api/auth/quota",
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+# ── Blocked email domains ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_register_blocked_email_domain(client):
+    """Registration is rejected when the email domain is in BLOCKED_EMAIL_DOMAINS."""
+    with patch.object(settings, "BLOCKED_EMAIL_DOMAINS", ["blocked.com"]):
+        response = await client.post(
+            "/api/auth/register",
+            json={
+                "username": "blockeduser",
+                "email": "user@blocked.com",
+                "password": "Test1234!@",
+                "display_name": "Blocked User",
+                "native_language": "es",
+            },
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_register_allowed_domain_passes(client):
+    """Registration with a non-blocked domain succeeds when BLOCKED_EMAIL_DOMAINS is set."""
+    with patch.object(settings, "BLOCKED_EMAIL_DOMAINS", ["blocked.com"]):
+        response = await client.post(
+            "/api/auth/register",
+            json={
+                "username": "alloweduser",
+                "email": "user@allowed.com",
+                "password": "Test1234!@",
+                "display_name": "Allowed User",
+                "native_language": "es",
+            },
+        )
+    assert response.status_code == 200

--- a/backend/tests/test_chat_conversations.py
+++ b/backend/tests/test_chat_conversations.py
@@ -1,0 +1,198 @@
+"""Tests for chat conversation CRUD: list, create, delete, get messages."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from app.core.security import create_access_token, hash_password
+from app.models.user import User
+
+
+# ── Helper: create a second user for ownership tests ─────────────────────────
+
+@pytest_asyncio.fixture
+async def other_user(db_session):
+    user = User(
+        username="otheruser",
+        email="other@example.com",
+        display_name="Other User",
+        hashed_password=hash_password("otherpass"),
+        role="user",
+        native_language="fr",
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    token = create_access_token(user.id, user.role)
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+# ── GET /api/chat/conversations ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_list_conversations_empty(client, test_user):
+    """A new user has no conversations."""
+    _, headers = test_user
+    response = await client.get("/api/chat/conversations", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_requires_auth(client):
+    response = await client.get(
+        "/api/chat/conversations",
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+# ── POST /api/chat/conversations ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_create_conversation_with_title(client, test_user):
+    """POST creates a conversation with the given title."""
+    _, headers = test_user
+    response = await client.post(
+        "/api/chat/conversations",
+        headers=headers,
+        json={"title": "My conversation"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "My conversation"
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_default_title(client, test_user):
+    """POST without a title falls back to 'New conversation'."""
+    _, headers = test_user
+    response = await client.post(
+        "/api/chat/conversations",
+        headers=headers,
+        json={},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "New conversation"
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_after_create(client, test_user):
+    """Created conversation appears in the list."""
+    _, headers = test_user
+    await client.post(
+        "/api/chat/conversations",
+        headers=headers,
+        json={"title": "Visible conversation"},
+    )
+    response = await client.get("/api/chat/conversations", headers=headers)
+    assert response.status_code == 200
+    titles = [c["title"] for c in response.json()]
+    assert "Visible conversation" in titles
+
+
+# ── DELETE /api/chat/conversations/{id} ───────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_delete_conversation_removes_it(client, test_user):
+    """DELETE removes the conversation; subsequent list is empty."""
+    _, headers = test_user
+    create_resp = await client.post(
+        "/api/chat/conversations",
+        headers=headers,
+        json={"title": "To delete"},
+    )
+    conv_id = create_resp.json()["id"]
+
+    del_resp = await client.delete(f"/api/chat/conversations/{conv_id}", headers=headers)
+    assert del_resp.status_code == 204
+
+    list_resp = await client.get("/api/chat/conversations", headers=headers)
+    assert list_resp.status_code == 200
+    assert all(c["id"] != conv_id for c in list_resp.json())
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_not_found(client, test_user):
+    """DELETE on a non-existent ID returns 404."""
+    _, headers = test_user
+    response = await client.delete("/api/chat/conversations/99999", headers=headers)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_other_users_conversation(client, test_user, other_user, db_session):
+    """A user cannot delete a conversation that belongs to someone else."""
+    _, headers_owner = test_user
+    _, headers_other = other_user
+
+    # Owner creates a conversation
+    create_resp = await client.post(
+        "/api/chat/conversations",
+        headers=headers_owner,
+        json={"title": "Owner's conv"},
+    )
+    conv_id = create_resp.json()["id"]
+
+    # Other user tries to delete it
+    response = await client.delete(
+        f"/api/chat/conversations/{conv_id}",
+        headers=headers_other,
+    )
+    assert response.status_code == 404
+
+
+# ── GET /api/chat/conversations/{id}/messages ─────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_conversation_messages_empty(client, test_user):
+    """Messages endpoint returns empty list for a new conversation."""
+    _, headers = test_user
+    create_resp = await client.post(
+        "/api/chat/conversations",
+        headers=headers,
+        json={"title": "Empty conv"},
+    )
+    conv_id = create_resp.json()["id"]
+
+    response = await client.get(
+        f"/api/chat/conversations/{conv_id}/messages",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_messages_not_found(client, test_user):
+    """Messages endpoint returns 404 for a non-existent conversation."""
+    _, headers = test_user
+    response = await client.get(
+        "/api/chat/conversations/99999/messages",
+        headers=headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_other_users_conversation_messages(client, test_user, other_user):
+    """A user cannot read messages from another user's conversation."""
+    _, headers_owner = test_user
+    _, headers_other = other_user
+
+    create_resp = await client.post(
+        "/api/chat/conversations",
+        headers=headers_owner,
+        json={"title": "Private"},
+    )
+    conv_id = create_resp.json()["id"]
+
+    response = await client.get(
+        f"/api/chat/conversations/{conv_id}/messages",
+        headers=headers_other,
+    )
+    assert response.status_code == 404

--- a/backend/tests/test_flashcards_extra.py
+++ b/backend/tests/test_flashcards_extra.py
@@ -1,0 +1,197 @@
+"""Extra flashcard tests: GET /all and POST /generate (LLM bulk generation)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.schemas.flashcards import FlashcardGenerateResponse, GeneratedFlashcard
+
+
+# ── GET /api/flashcards/all ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_all_flashcards_empty(client, test_user):
+    """New user has no flashcards."""
+    _, headers = test_user
+    response = await client.get("/api/flashcards/all", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_all_flashcards_returns_non_due_cards(client, test_user, db_session):
+    """GET /all returns cards even if they are not yet due for review."""
+    user, headers = test_user
+
+    from datetime import date, timedelta
+    from app.models.flashcard import Flashcard
+
+    # Card with a future review date (not "due" yet)
+    future_card = Flashcard(
+        user_id=user.id,
+        word="serendipity",
+        definition="finding something nice while not looking for it",
+        example_sentence="It was serendipity that we met.",
+        translation="serendipia",
+        next_review=date.today() + timedelta(days=10),
+        interval=10,
+        repetitions=2,
+    )
+    db_session.add(future_card)
+    await db_session.commit()
+
+    response = await client.get("/api/flashcards/all", headers=headers)
+    assert response.status_code == 200
+    words = [c["word"] for c in response.json()]
+    assert "serendipity" in words
+
+
+@pytest.mark.asyncio
+async def test_get_all_excludes_other_users_cards(client, test_user, db_session):
+    """GET /all only returns the current user's own flashcards."""
+    user, headers = test_user
+
+    from app.core.security import hash_password
+    from app.models.flashcard import Flashcard
+    from app.models.user import User
+
+    # Create a second user with their own card
+    other = User(
+        username="other2",
+        email="other2@example.com",
+        display_name="Other 2",
+        hashed_password=hash_password("pass"),
+        role="user",
+        native_language="es",
+        is_active=True,
+    )
+    db_session.add(other)
+    await db_session.flush()
+
+    db_session.add(Flashcard(
+        user_id=other.id,
+        word="foreignword",
+        definition="def",
+        example_sentence="ex.",
+        translation="t",
+    ))
+    await db_session.commit()
+
+    response = await client.get("/api/flashcards/all", headers=headers)
+    assert response.status_code == 200
+    words = [c["word"] for c in response.json()]
+    assert "foreignword" not in words
+
+
+@pytest.mark.asyncio
+async def test_get_all_requires_auth(client):
+    response = await client.get(
+        "/api/flashcards/all",
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+# ── POST /api/flashcards/generate ────────────────────────────────────────────
+
+_FAKE_GENERATED = FlashcardGenerateResponse(
+    flashcards=[
+        GeneratedFlashcard(
+            word="ubiquitous",
+            definition="present, appearing, or found everywhere",
+            example_sentence="Mobile phones are ubiquitous nowadays.",
+            translation="ubicuo",
+        ),
+        GeneratedFlashcard(
+            word="ephemeral",
+            definition="lasting for a very short time",
+            example_sentence="Social media trends are ephemeral.",
+            translation="efímero",
+        ),
+    ]
+)
+
+
+@pytest.mark.asyncio
+async def test_generate_flashcards_success(client, test_user, db_session):
+    """POST /generate calls the LLM and persists the returned cards."""
+    user, headers = test_user
+
+    with patch(
+        "app.routers.flashcards.generate_flashcards",
+        new_callable=AsyncMock,
+        return_value=_FAKE_GENERATED,
+    ):
+        response = await client.post(
+            "/api/flashcards/generate",
+            headers=headers,
+            json={"topic": "technology", "count": 2, "cefr_level": "B2", "native_language": "es"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["flashcards"]) == 2
+    words = [c["word"] for c in data["flashcards"]]
+    assert "ubiquitous" in words
+
+    # Verify cards were persisted
+    from app.models.flashcard import Flashcard
+    from sqlalchemy import select
+    result = await db_session.execute(
+        select(Flashcard).where(Flashcard.user_id == user.id)
+    )
+    saved = result.scalars().all()
+    assert len(saved) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_flashcards_llm_timeout(client, test_user):
+    """POST /generate returns 504 when the LLM times out."""
+    _, headers = test_user
+
+    from app.services.llm_adapter import LLMTimeoutError
+
+    with patch(
+        "app.routers.flashcards.generate_flashcards",
+        new_callable=AsyncMock,
+        side_effect=LLMTimeoutError("timeout"),
+    ):
+        response = await client.post(
+            "/api/flashcards/generate",
+            headers=headers,
+            json={"topic": "animals", "count": 3, "cefr_level": "A2", "native_language": "es"},
+        )
+
+    assert response.status_code == 504
+
+
+@pytest.mark.asyncio
+async def test_generate_flashcards_llm_unavailable(client, test_user):
+    """POST /generate returns 503 when the LLM service is unavailable."""
+    _, headers = test_user
+
+    from app.services.llm_adapter import LLMUnavailableError
+
+    with patch(
+        "app.routers.flashcards.generate_flashcards",
+        new_callable=AsyncMock,
+        side_effect=LLMUnavailableError("down"),
+    ):
+        response = await client.post(
+            "/api/flashcards/generate",
+            headers=headers,
+            json={"topic": "sports", "count": 3, "cefr_level": "B1", "native_language": "es"},
+        )
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_generate_flashcards_requires_auth(client):
+    response = await client.post(
+        "/api/flashcards/generate",
+        headers={"Authorization": "Bearer invalid"},
+        json={"topic": "food", "count": 2, "cefr_level": "A1", "native_language": "es"},
+    )
+    assert response.status_code == 401

--- a/backend/tests/test_lessons_extra.py
+++ b/backend/tests/test_lessons_extra.py
@@ -1,0 +1,104 @@
+"""Tests for POST /api/lessons/{id}/start."""
+from __future__ import annotations
+
+import pytest
+
+
+async def _create_lesson_with_plan(db_session, user_id: int):
+    """Helper: create a StudyPlan + Lesson owned by the given user."""
+    from app.models.lesson import Lesson
+    from app.models.study_plan import StudyPlan
+
+    plan = StudyPlan(
+        user_id=user_id,
+        cefr_level="A2",
+        goals=["grammar"],
+        duration_weeks=4,
+        days_per_week=4,
+        current_unit="",
+        generated_plan={},
+        is_active=True,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+
+    lesson = Lesson(
+        study_plan_id=plan.id,
+        title="Start Me",
+        lesson_type="vocabulary",
+        cefr_level="A2",
+        week_number=1,
+        day_number=1,
+        content={},
+    )
+    db_session.add(lesson)
+    await db_session.commit()
+    await db_session.refresh(lesson)
+    return lesson
+
+
+# ── POST /api/lessons/{id}/start ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_start_lesson_success(client, test_user, db_session):
+    """POST /start returns 200 with the lesson data."""
+    user, headers = test_user
+    lesson = await _create_lesson_with_plan(db_session, user.id)
+
+    response = await client.post(
+        f"/api/lessons/{lesson.id}/start",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == lesson.id
+    assert data["title"] == "Start Me"
+
+
+@pytest.mark.asyncio
+async def test_start_lesson_not_found(client, test_user):
+    """POST /start on a non-existent lesson returns 404."""
+    _, headers = test_user
+    response = await client.post("/api/lessons/99999/start", headers=headers)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_start_lesson_requires_auth(client):
+    """POST /start without a valid token returns 401."""
+    response = await client.post(
+        "/api/lessons/1/start",
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_start_lesson_other_user_forbidden(client, test_user, db_session):
+    """A user cannot start a lesson that belongs to a different user's plan."""
+    from app.core.security import create_access_token, hash_password
+    from app.models.user import User
+
+    # Create the lesson owner
+    owner = User(
+        username="lessonowner",
+        email="lessonowner@example.com",
+        display_name="Lesson Owner",
+        hashed_password=hash_password("ownerpass"),
+        role="user",
+        native_language="es",
+        is_active=True,
+    )
+    db_session.add(owner)
+    await db_session.commit()
+    await db_session.refresh(owner)
+
+    lesson = await _create_lesson_with_plan(db_session, owner.id)
+
+    # Try to start it as a different user
+    _, headers_other = test_user
+    response = await client.post(
+        f"/api/lessons/{lesson.id}/start",
+        headers=headers_other,
+    )
+    assert response.status_code == 404

--- a/backend/tests/test_listening_extra.py
+++ b/backend/tests/test_listening_extra.py
@@ -1,0 +1,203 @@
+"""Extra listening tests: GET /history and GET /audio/{id} (not covered in test_listening.py)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.core.database import get_db
+from app.core.security import create_access_token, hash_password
+from app.main import app
+from app.models.user import User
+
+
+# ---------------------------------------------------------------------------
+# Local Redis mock (matching the one in test_listening.py for consistency)
+# ---------------------------------------------------------------------------
+
+class _MockRedis:
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    async def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None):
+        if nx and key in self._store:
+            return None
+        self._store[key] = value
+        return True
+
+    async def get(self, key: str):
+        return self._store.get(key)
+
+    async def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
+    async def setex(self, key: str, ttl: int, value: str) -> None:
+        self._store[key] = value
+
+    async def getex(self, key: str):
+        return self._store.get(key)
+
+    async def aclose(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def listening_client(db_session):
+    """Client with listening Redis overridden (needed for /next and /generate).
+    For /history and /audio the Redis override is irrelevant but kept for
+    consistency with the rest of the listening test suite."""
+    from app.routers.auth import get_redis as auth_get_redis
+    from app.routers.admin import get_redis as admin_get_redis
+    from app.routers.assessment import get_redis as assessment_get_redis
+    from app.routers.listening import get_redis as listening_get_redis
+
+    mock_redis = _MockRedis()
+
+    async def override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[auth_get_redis] = lambda: mock_redis
+    app.dependency_overrides[admin_get_redis] = lambda: mock_redis
+    app.dependency_overrides[assessment_get_redis] = lambda: mock_redis
+    app.dependency_overrides[listening_get_redis] = lambda: mock_redis
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def listening_user(db_session):
+    user = User(
+        username="luser",
+        email="luser@example.com",
+        display_name="Listening User",
+        hashed_password=hash_password("lpass"),
+        role="user",
+        native_language="es",
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    token = create_access_token(user.id, user.role)
+    return user, {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/listening/history
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_listening_history_empty(listening_client, listening_user):
+    """A user with no attempts has an empty history."""
+    _, headers = listening_user
+    response = await listening_client.get("/api/listening/history", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_listening_history_pagination_fields(listening_client, listening_user):
+    """History response includes skip and limit pagination metadata."""
+    _, headers = listening_user
+    response = await listening_client.get(
+        "/api/listening/history?skip=0&limit=5",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "skip" in data
+    assert "limit" in data
+    assert data["skip"] == 0
+    assert data["limit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_listening_history_limit_capped_at_50(listening_client, listening_user):
+    """Requesting limit=100 is silently capped to 50."""
+    _, headers = listening_user
+    response = await listening_client.get(
+        "/api/listening/history?skip=0&limit=100",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["limit"] <= 50
+
+
+@pytest.mark.asyncio
+async def test_listening_history_requires_auth(listening_client):
+    response = await listening_client.get(
+        "/api/listening/history",
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/listening/audio/{exercise_id}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_listening_audio_exercise_not_found(listening_client, listening_user):
+    """Requesting audio for a non-existent exercise returns 404."""
+    _, headers = listening_user
+    response = await listening_client.get("/api/listening/audio/99999", headers=headers)
+    assert response.status_code == 404
+    assert response.json()["detail"] == "exercise_not_found"
+
+
+@pytest.mark.asyncio
+async def test_listening_audio_file_not_found(listening_client, listening_user, db_session):
+    """If the exercise exists but the MP3 file is missing on disk, return 404."""
+    from app.models.listening import ListeningExercise
+
+    _, headers = listening_user
+    exercise = ListeningExercise(
+        cefr_level="B1",
+        text="Test audio text.",
+        questions=[],
+        audio_path="/nonexistent/path/999.mp3",
+    )
+    db_session.add(exercise)
+    await db_session.commit()
+    await db_session.refresh(exercise)
+
+    response = await listening_client.get(
+        f"/api/listening/audio/{exercise.id}",
+        headers=headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "audio_not_found"
+
+
+@pytest.mark.asyncio
+async def test_listening_audio_requires_auth(listening_client):
+    response = await listening_client.get(
+        "/api/listening/audio/1",
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_listening_audio_non_integer_id_rejected(listening_client, listening_user):
+    """FastAPI path validation rejects non-integer exercise IDs before the handler runs."""
+    _, headers = listening_user
+    response = await listening_client.get(
+        "/api/listening/audio/not-an-int",
+        headers=headers,
+    )
+    assert response.status_code == 422

--- a/backend/tests/test_listening_extra.py
+++ b/backend/tests/test_listening_extra.py
@@ -166,7 +166,10 @@ async def test_listening_audio_file_not_found(listening_client, listening_user, 
 
     _, headers = listening_user
     exercise = ListeningExercise(
-        cefr_level="B1",
+        level="B1",
+        target_language="en-US",
+        exercise_type="monologue",
+        topic="test",
         text="Test audio text.",
         questions=[],
         audio_path="/nonexistent/path/999.mp3",

--- a/backend/tests/test_progress_extra.py
+++ b/backend/tests/test_progress_extra.py
@@ -1,0 +1,82 @@
+"""Tests for GET /api/progress/competencies (per-unit skill scores)."""
+from __future__ import annotations
+
+import pytest
+
+
+# ── GET /api/progress/competencies ───────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_competencies_empty_for_new_user(client, test_user):
+    """A user with no study plan or exercises has an empty competencies list."""
+    _, headers = test_user
+    response = await client.get("/api/progress/competencies", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_competencies_requires_auth(client):
+    response = await client.get(
+        "/api/progress/competencies",
+        headers={"Authorization": "Bearer invalid"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_competencies_returns_list_shape(client, test_user, db_session):
+    """After completing a lesson with exercises, competencies returns list items
+    with the expected keys: unit_id, score, mastered_count, total_count."""
+    user, headers = test_user
+
+    from app.models.lesson import Exercise, Lesson
+    from app.models.study_plan import StudyPlan
+
+    plan = StudyPlan(
+        user_id=user.id,
+        cefr_level="A1",
+        goals=["grammar"],
+        duration_weeks=4,
+        days_per_week=4,
+        current_unit="A1-u1",
+        generated_plan={},
+        is_active=True,
+    )
+    db_session.add(plan)
+    await db_session.flush()
+
+    lesson = Lesson(
+        study_plan_id=plan.id,
+        title="Unit 1 Lesson",
+        lesson_type="grammar",
+        cefr_level="A1",
+        week_number=1,
+        day_number=1,
+        unit_id="A1-u1",
+        is_completed=True,
+        content={},
+    )
+    db_session.add(lesson)
+    await db_session.flush()
+
+    exercise = Exercise(
+        lesson_id=lesson.id,
+        exercise_type="multiple_choice",
+        question="Q?",
+        options=["A", "B"],
+        correct_answer="A",
+        score=1.0,
+    )
+    db_session.add(exercise)
+    await db_session.commit()
+
+    response = await client.get("/api/progress/competencies", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    # If any items returned, verify their shape
+    for item in data:
+        assert "unit_id" in item
+        assert "score" in item
+        assert "mastered_count" in item
+        assert "total_count" in item


### PR DESCRIPTION
This pull request adds comprehensive test coverage for several API endpoints related to authentication, admin user management, chat conversations, flashcards, and lesson starting. The new tests cover both standard and edge cases, including permission checks, error handling, and integration with external services (such as LLMs for flashcard generation). This significantly improves the reliability and robustness of the backend by ensuring correct behavior and access control for all major features.

The most important changes are:

**Authentication and Authorization**

* Added tests for account deletion (`DELETE /api/auth/me`), including checks for required authentication, admin restrictions, and refresh token cookie clearing.
* Added tests for user quota retrieval (`GET /api/auth/quota`) and for blocking registration from certain email domains.

**Admin Endpoints**

* Added tests for admin-only endpoints to fetch user stats (`GET /api/admin/users/{id}/stats`) and quota (`GET /api/admin/users/{id}/quota`), including permission checks and not-found handling.

**Chat Conversations**

* Added CRUD tests for chat conversations: listing, creation (with and without titles), deletion, and message retrieval. Tests verify correct ownership, access control, and error responses.

**Flashcards**

* Added tests for bulk flashcard retrieval (`GET /api/flashcards/all`) ensuring users only see their own cards, and for LLM-powered flashcard generation (`POST /api/flashcards/generate`), including error handling for timeouts and service unavailability.

**Lessons**

* Added tests for starting a lesson (`POST /api/lessons/{id}/start`), including ownership checks, not-found, and authentication requirements.