### PR TITLE
feature: change request for Anthropic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - 2026-05-18
+
+### Fixed
+- **Anthropic LLM provider**: resolved crash `'NoneType' object has no attribute 'beta'` in `structured_output` caused by routing Anthropic through `_do_structured_output`, which uses the OpenAI `beta.chat.completions.parse` API while `self.client` is `None` for Anthropic. All providers now go through `_structured_via_json`.
+- **Anthropic — system prompt lost**: `_anthropic_chat` was extracting only the first system message via `next()`; extra instructions appended by `_structured_via_json` (JSON format hint) were silently dropped. All system messages are now combined with `\n\n` before the API call.
+- **Anthropic — `system=None` API error**: passing `system=None` explicitly to `messages.create` could cause an SDK validation error; the parameter is now omitted when no system message is present.
+- **Anthropic — missing timeout**: `messages.create` calls had no `timeout` guard; `REQUEST_TIMEOUT` (60 s) is now applied.
+- **Anthropic — double retry**: `_anthropic_chat` wrapped the API call in its own `_call_with_retry`, nesting it inside the outer retry loop in `_do_chat` (up to 9 attempts). The inner retry was removed; the outer loop is sufficient.
+- **Dead code removed**: `_do_structured_output` (referenced `self.client.beta` — broken for Anthropic, unreachable for all providers) deleted.
+
 ## [1.5.3] - 2026-05-17
 
 ### Added

--- a/backend/app/services/llm_adapter.py
+++ b/backend/app/services/llm_adapter.py
@@ -184,24 +184,7 @@ class LLMAdapter:
         self, messages: list[dict], schema: type[BaseModel]
     ) -> BaseModel:
         # Use JSON mode for all providers — more reliable across versions
-        if self.provider == "anthropic":
-            return await self._call_with_retry(self._do_structured_output, messages, schema)
         return await self._structured_via_json(messages, schema)
-
-    async def _do_structured_output(self, messages: list[dict], schema: type[BaseModel]):
-        response = await self.client.beta.chat.completions.parse(
-            model=self.model,
-            messages=messages,
-            response_format=schema,
-            timeout=REQUEST_TIMEOUT,
-        )
-        parsed = response.choices[0].message.parsed
-        if parsed is None:
-            raise LLMResponseError(
-                "LLM refused to generate structured output",
-                raw_response=str(response.choices[0].message.refusal or ""),
-            )
-        return parsed
 
     async def _structured_via_json(
         self, messages: list[dict], schema: type[BaseModel]
@@ -250,29 +233,31 @@ class LLMAdapter:
                 ) from e2
 
     async def _anthropic_chat(self, messages: list[dict], stream: bool = False):
-        async def call():
-            system = next(
-                (m["content"] for m in messages if m["role"] == "system"), None
-            )
-            user_messages = [
-                m for m in messages if m["role"] != "system"
-            ]
+        # Combine ALL system messages so that extra instructions (e.g. the
+        # JSON format hint appended by _structured_via_json) are not silently
+        # dropped by a naive next()-based extraction.
+        system_parts = [m["content"] for m in messages if m["role"] == "system"]
+        system = "\n\n".join(system_parts) if system_parts else None
+        user_messages = [m for m in messages if m["role"] != "system"]
 
-            response = await self._anthropic.messages.create(
-                model=self.model,
-                system=system,
-                messages=user_messages,
-                max_tokens=4096,
-                stream=stream,
-            )
-            if stream:
-                return response
-            content = response.content[0].text if response.content else ""
-            if not content:
-                raise LLMResponseError("Anthropic returned empty response")
-            return content
+        kwargs: dict = dict(
+            model=self.model,
+            messages=user_messages,
+            max_tokens=4096,
+            stream=stream,
+            timeout=REQUEST_TIMEOUT,
+        )
+        # Only pass system when present — Anthropic SDK does not accept None.
+        if system is not None:
+            kwargs["system"] = system
 
-        return await self._call_with_retry(call)
+        response = await self._anthropic.messages.create(**kwargs)
+        if stream:
+            return response
+        content = response.content[0].text if response.content else ""
+        if not content:
+            raise LLMResponseError("Anthropic returned empty response")
+        return content
 
 
 llm_adapter = LLMAdapter()

--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -240,7 +240,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <p className="text-fl-label font-mono text-fl-muted-4 truncate">@{user?.username}</p>
             </div>
           </div>
-          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.5.3</p>
+          <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.5.4</p>
           <button
             onClick={() => setLogoutConfirm(true)}
             className="w-full text-left text-fl-label font-mono tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"
@@ -359,7 +359,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </div>
                 <p className="font-mono text-fl-label text-fl-muted-4 truncate">@{user?.username}</p>
               </div>
-              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.5.3</p>
+              <p className="font-mono text-fl-label text-fl-muted-4 tracking-wider mb-2">v1.5.4</p>
               <button
                 onClick={() => { setMobileMenuOpen(false); setLogoutConfirm(true) }}
                 className="font-mono text-fl-label tracking-widest text-fl-muted-2 hover:text-fl-fg transition-colors uppercase"

--- a/frontend/src/components/whats-new/WhatsNew.tsx
+++ b/frontend/src/components/whats-new/WhatsNew.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useTranslations, useMessages } from 'next-intl'
 
-const WHATS_NEW_VERSION = 'v1.5.3'
+const WHATS_NEW_VERSION = 'v1.5.4'
 const STORAGE_KEY = `fl_whats_new_seen_${WHATS_NEW_VERSION}`
 const TOUR_KEY = 'fl_tour_done'
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Neuigkeiten",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Verstanden",
     "entry1": {
       "label": "Reading",

--- a/messages/en.json
+++ b/messages/en.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "What's New",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Got it",
     "entry1": {
       "label": "Reading",

--- a/messages/es.json
+++ b/messages/es.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Novedades",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Entendido",
     "entry1": {
       "label": "Reading",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Nouveautés",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Compris",
     "entry1": {
       "label": "Reading",

--- a/messages/it.json
+++ b/messages/it.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Novità",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Capito",
     "entry1": {
       "label": "Reading",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Nieuw",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Begrepen",
     "entry1": {
       "label": "Reading",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Co nowego",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Rozumiem",
     "entry1": {
       "label": "Reading",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Novidades",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Entendido",
     "entry1": {
       "label": "Reading",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Noutăți",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Am înțeles",
     "entry1": {
       "label": "Reading",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -928,7 +928,7 @@
   },
   "whatsNew": {
     "title": "Что нового",
-    "version": "v1.5.3",
+    "version": "v1.5.4",
     "cta": "Понятно",
     "entry1": {
       "label": "Reading",

--- a/specs/version.md
+++ b/specs/version.md
@@ -1,6 +1,6 @@
 # Version
 
-**1.5.3**
+**1.5.4**
 
 > Canonical project version. Update this file when bumping.
 > Full history in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
This pull request updates the project to version 1.5.4 and delivers several important fixes for the Anthropic LLM provider, along with associated version bumps across the codebase and documentation. The main focus is on stabilizing and improving the Anthropic integration, especially around structured output handling and system prompt management.

### Anthropic LLM Provider Fixes

* Fixed a crash when using Anthropic with `structured_output` by removing the broken `_do_structured_output` method and ensuring all providers now use `_structured_via_json`. This avoids reliance on OpenAI-specific APIs and ensures compatibility. [[1]](diffhunk://#diff-ef97b90ca7279cdccb73a829d015217a294df106e9afe6162f916ecaf67107b5L187-L205) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R17)
* Ensured all system messages are combined and passed to Anthropic, preventing loss of appended instructions (such as JSON format hints) that were previously dropped. [[1]](diffhunk://#diff-ef97b90ca7279cdccb73a829d015217a294df106e9afe6162f916ecaf67107b5L253-L276) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R17)
* Fixed an API error by omitting the `system` parameter entirely if no system message is present, preventing Anthropic SDK validation errors when `None` was passed. [[1]](diffhunk://#diff-ef97b90ca7279cdccb73a829d015217a294df106e9afe6162f916ecaf67107b5L253-L276) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R17)
* Added a timeout (`REQUEST_TIMEOUT`, 60s) to Anthropic `messages.create` calls to prevent potential hangs. [[1]](diffhunk://#diff-ef97b90ca7279cdccb73a829d015217a294df106e9afe6162f916ecaf67107b5L253-L276) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R17)
* Removed redundant retry logic in `_anthropic_chat` to avoid double retry loops, relying on the outer retry mechanism only. [[1]](diffhunk://#diff-ef97b90ca7279cdccb73a829d015217a294df106e9afe6162f916ecaf67107b5L253-L276) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R17)

### Dead Code Removal

* Deleted the `_do_structured_output` method, which was unreachable and referenced APIs not available for Anthropic. [[1]](diffhunk://#diff-ef97b90ca7279cdccb73a829d015217a294df106e9afe6162f916ecaf67107b5L187-L205) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R17)

### Version Bump and Documentation

* Updated all references to the project version from `v1.5.3` to `v1.5.4` in UI, internationalization files, and documentation (`CHANGELOG.md`, `specs/version.md`). [[1]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L243-R243) [[2]](diffhunk://#diff-df92aeb2be4b955617adab9ae0f3698582c54d1c3366a1ac0e12fa687ed29726L362-R362) [[3]](diffhunk://#diff-dc21c710521e9b68b8074528c8300e6589b994b02940992ed2225c9085ec9554L6-R6) [[4]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL931-R931) [[5]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158L931-R931) [[6]](diffhunk://#diff-d53ec28a25a019b0692483a34e3c0f4a6e441c84178630e95c2ebe71f05297f2L931-R931) [[7]](diffhunk://#diff-f770b8f2b7d3575a8bb27583d9d3ccbe7eab7a29922bab964d595cd2b8514877L931-R931) [[8]](diffhunk://#diff-4e0aa612af7564eb28a3c5a68ac8c5c0779a777a7b411c370dd43cf45af68778L931-R931) [[9]](diffhunk://#diff-361894c680a14e4cb761ad80196ca5dcd0bb4d64a33f839f510fca7f8bacf62bL931-R931) [[10]](diffhunk://#diff-21ebedd5d51c4cdb2ec01182e574d64802318d89672e592edf3b0b1c787324faL931-R931) [[11]](diffhunk://#diff-e7f6219511cfdbf367e656ee21bf93dba648011492721e6ab7d416bdb25fae43L931-R931) [[12]](diffhunk://#diff-06261576a97da8b3a1cfa91dad6890e3965482f51a30df03d182e079a20f55fdL931-R931) [[13]](diffhunk://#diff-5e75b39fcc008a0e8044f12470210a976838de980c8671485ce301d0a5ac0a77L931-R931) [[14]](diffhunk://#diff-cfdb8fe68f746bbaa621c431c59ab7173433a98dddb19fd98f5ee52586c912bdL3-R3)

These changes improve reliability and maintainability for Anthropic LLM usage and ensure version consistency throughout the project.