### PR TITLE
feature: deploy to main

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FreeLingo — AI-powered language learning, self-hosted</title>
   <meta name="description"
-    content="Open source, self-hosted language learning platform powered by local AI. CEFR-aligned study plans, spaced repetition flashcards, and a streaming AI tutor." />
+    content="Open source, self-hosted language learning platform powered by local AI. CEFR placement test, personalized study plans, spaced repetition flashcards, AI tutor chat, voice conversation, listening exercises, reading practice, and a full learning resources hub." />
   <link rel="icon" href="assets/logo.png" />
   <link rel="stylesheet" href="css/style.css" />
 </head>
@@ -39,7 +39,8 @@
       <p class="hero-subtitle">
         Open source, self-hosted language learning with AI.<br />
         A local LLM evaluates your CEFR level, builds a personalized study plan,
-        and guides you through lessons, flashcards, and live tutor chat.
+        and guides you through lessons, spaced-repetition flashcards, AI tutor chat,
+        voice conversation, listening exercises, reading practice, and a full learning resources hub.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="https://freelingo.app" target="_blank" rel="noopener">Try the Hosted
@@ -91,8 +92,8 @@
 
         <div class="feature-card">
           <div class="feature-icon">🎙️</div>
-          <h3>Voice Support</h3>
-          <p>TTS playback (Kokoro) and STT dictation (faster-whisper) for pronunciation practice.</p>
+          <h3>Voice Conversation</h3>
+          <p>Real-time voice pipeline with TTS/STT, VAD, and barge-in for live speaking practice with the AI tutor.</p>
         </div>
 
         <div class="feature-card">
@@ -102,15 +103,15 @@
         </div>
 
         <div class="feature-card">
-          <div class="feature-icon">🤖</div>
-          <h3>Any LLM Provider</h3>
-          <p>Ollama (local), OpenAI, Anthropic, or DeepSeek. Switch providers with a single setting.</p>
+          <div class="feature-icon">🎧</div>
+          <h3>Listening Exercises</h3>
+          <p>AI-generated audio exercises to train comprehension at your CEFR level.</p>
         </div>
 
         <div class="feature-card">
           <div class="feature-icon">🔒</div>
-          <h3>Privacy First</h3>
-          <p>100% self-hosted. Your data, your server, your rules. Multi-user with invite-only registration.</p>
+          <h3>Privacy First &amp; Any LLM</h3>
+          <p>100% self-hosted with Ollama, OpenAI, Anthropic, or DeepSeek. Your data, your server, your rules.</p>
         </div>
 
       </div>
@@ -177,10 +178,11 @@ cp .env.example .env
       <p class="section-label">Open Source</p>
       <h2>Built in the open, auditable by anyone</h2>
       <p>
-        FreeLingo is free and open source under the Apache 2.0 license.<br />
+        FreeLingo is free and open source under the AGPL-3.0 license.<br />
         Browse the code, report issues, or contribute on GitHub.<br />
         Prefer a managed experience? Use the hosted service at <a href="https://freelingo.app" target="_blank"
-          rel="noopener">freelingo.app</a> — no server required.
+          rel="noopener">freelingo.app</a> — no server required.<br />
+        Need to deploy without open-source obligations? A commercial licence is available for organisations.
       </p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="https://github.com/ArtCC/freelingo" target="_blank" rel="noopener"><svg
@@ -195,16 +197,7 @@ cp .env.example .env
 
   <!-- FOOTER -->
   <footer>
-    <div class="footer-links">
-      <a href="https://github.com/ArtCC/freelingo" target="_blank" rel="noopener"><svg class="gh-icon"
-          viewBox="0 0 16 16" aria-hidden="true">
-          <path
-            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
-        </svg> GitHub</a>
-      <a href="https://github.com/ArtCC/freelingo/blob/main/LICENSE" target="_blank" rel="noopener">Apache 2.0</a>
-    </div>
-    <p>Made by <a href="https://github.com/ArtCC" target="_blank" rel="noopener">Arturo Carretero Calvo</a> · Apache 2.0
-    </p>
+    <p>Made by <a href="https://github.com/ArtCC" target="_blank" rel="noopener">Arturo Carretero Calvo</a></p>
   </footer>
 
   <script src="js/script.js"></script>


### PR DESCRIPTION
This pull request updates the landing page content for FreeLingo to better reflect its features and licensing. The main changes expand the feature descriptions, clarify available AI and voice capabilities, update the open source license from Apache 2.0 to AGPL-3.0, and add information about commercial licensing. The footer has also been simplified.

**Feature and Description Updates:**

* Expanded the main meta description and hero subtitle in `docs/index.html` to include new features such as CEFR placement test, voice conversation, listening exercises, reading practice, and a learning resources hub. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL9-R9) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL42-R43)
* Updated feature cards to rename "Voice Support" to "Voice Conversation" with details about real-time voice pipeline, and added a new "Listening Exercises" card describing AI-generated audio comprehension training. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL94-R96) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL105-R114)
* Combined "Privacy First" and "Any LLM Provider" into one feature card, clarifying support for multiple LLM providers and emphasizing self-hosting.

**Licensing and Footer Updates:**

* Changed the open source license reference from Apache 2.0 to AGPL-3.0 and added a note about the availability of a commercial license for organizations.
* Simplified the footer by removing license and GitHub links, keeping only author attribution.