### PR TITLE
feature: deploy to main

### DIFF
--- a/backend/alembic/versions/0024_lessons_unique.py
+++ b/backend/alembic/versions/0024_lessons_unique.py
@@ -15,6 +15,27 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Remove duplicate lessons before adding the unique constraint.
+    # Duplicates exist in production because the IntegrityError guard was not
+    # yet in place. Strategy: per group keep the completed lesson (if any),
+    # otherwise keep the oldest (MIN id). DISTINCT ON is PostgreSQL-specific
+    # and safe here — we only ever run on PostgreSQL.
+    op.execute(
+        """
+        DELETE FROM lessons
+        WHERE id NOT IN (
+            SELECT DISTINCT ON (study_plan_id, week_number, day_number, title) id
+            FROM lessons
+            ORDER BY
+                study_plan_id,
+                week_number,
+                day_number,
+                title,
+                is_completed DESC,
+                id ASC
+        )
+        """
+    )
     op.create_unique_constraint(
         "uq_lessons_plan_week_day_title",
         "lessons",


### PR DESCRIPTION
This pull request updates the database migration for lessons to ensure data integrity before adding a unique constraint. The main change is a data cleanup step that removes duplicate lessons, ensuring that only the correct record is kept for each group.

**Database migration and data integrity:**

* Added a SQL command in `backend/alembic/versions/0024_lessons_unique.py` to remove duplicate lessons before applying a unique constraint. For each group, it keeps the completed lesson if available, otherwise the oldest one, using PostgreSQL-specific `DISTINCT ON`.