### PR TITLE
fix: rename Alembic migration file and update revision ID

### DIFF
--- a/backend/alembic/versions/0035_competency_unique.py
+++ b/backend/alembic/versions/0035_competency_unique.py
@@ -1,6 +1,6 @@
 """Add unique constraint on user_competencies to prevent duplicates per plan
 
-Revision ID: 0035_competency_unique_constraint
+Revision ID: 0035_competency_unique
 Revises: 0034_user_language_id_fk
 Create Date: 2026-06-05
 """
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0035_competency_unique_constraint"
+revision: str = "0035_competency_unique"
 down_revision: str | None = "0034_user_language_id_fk"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None


### PR DESCRIPTION
This pull request makes a minor update to the migration script for adding a unique constraint on `user_competencies`. The primary change is renaming the migration file and updating related identifiers to use a shorter, more consistent name.

- Renamed the migration file from `0035_competency_unique_constraint.py` to `0035_competency_unique.py` and updated the `Revision ID` and `revision` variable accordingly for consistency. [[1]](diffhunk://#diff-bc7a33d5858054fb67c9fe5be07a9f5fbc7d37686c79cb04811b5aea4338fa3fL3-R3) [[2]](diffhunk://#diff-bc7a33d5858054fb67c9fe5be07a9f5fbc7d37686c79cb04811b5aea4338fa3fL12-R12)