### PR TITLE
feature: fixes

### DIFF
--- a/backend/app/routers/languages.py
+++ b/backend/app/routers/languages.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.app_logger import get_logger
 from app.core.database import get_db
-from app.core.deps import require_subscription
+from app.core.deps import get_current_user
 from app.models.chat_history import ChatHistory
 from app.models.conversation import Conversation
 from app.models.llm_usage import LLMUsage
@@ -108,7 +108,7 @@ async def _build_progress_info(
 
 @router.get("", response_model=UserLanguageListResponse)
 async def list_languages(
-    current_user: User = Depends(require_subscription),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     from app.schemas.auth import get_available_languages
@@ -138,7 +138,7 @@ async def list_languages(
 
 @router.get("/active")
 async def get_active(
-    current_user: User = Depends(require_subscription),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     active = await get_active_language(db, current_user.id)
@@ -150,7 +150,7 @@ async def get_active(
 @router.post("", status_code=status.HTTP_201_CREATED)
 async def add_new_language(
     data: LanguageAddRequest,
-    current_user: User = Depends(require_subscription),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     entry = await add_language(db, current_user.id, data.target_language)
@@ -160,7 +160,7 @@ async def add_new_language(
 @router.put("/active")
 async def switch_active_language(
     data: LanguageSwitchRequest,
-    current_user: User = Depends(require_subscription),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     entry = await switch_language(db, current_user.id, data.target_language)
@@ -173,7 +173,7 @@ async def switch_active_language(
 @router.delete("/{target_language}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_language(
     target_language: str,
-    current_user: User = Depends(require_subscription),
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     # ── Find the UserLanguage row ────────────────────────────────────────

--- a/backend/app/routers/listening.py
+++ b/backend/app/routers/listening.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.database import get_db
-from app.core.deps import get_active_study_plan, get_current_user, get_redis, require_subscription
+from app.core.deps import get_active_study_plan, get_redis, require_subscription
 from app.core.limiter import limiter
 from app.models.listening import ListeningExercise
 from app.models.study_plan import StudyPlan
@@ -267,7 +267,7 @@ async def get_listening_history(
     skip: int = 0,
     limit: int = 10,
     plan: StudyPlan = Depends(get_active_study_plan),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_subscription),
     db: AsyncSession = Depends(get_db),
 ) -> ListeningHistoryResponse:
     """Return paginated list of the user's past listening attempts."""

--- a/backend/app/routers/reading.py
+++ b/backend/app/routers/reading.py
@@ -8,7 +8,7 @@ from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
-from app.core.deps import get_active_study_plan, get_current_user, get_redis, require_subscription
+from app.core.deps import get_active_study_plan, get_redis, require_subscription
 from app.core.limiter import limiter
 from app.models.study_plan import StudyPlan
 from app.models.user import User
@@ -216,7 +216,7 @@ async def get_reading_history(
     skip: int = 0,
     limit: int = 10,
     plan: StudyPlan = Depends(get_active_study_plan),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_subscription),
     db: AsyncSession = Depends(get_db),
 ) -> ReadingHistoryResponse:
     """Return paginated list of the user's past reading attempts."""

--- a/frontend/src/app/(app)/settings/languages/page.tsx
+++ b/frontend/src/app/(app)/settings/languages/page.tsx
@@ -96,8 +96,7 @@ export default function MyLanguagesPage() {
   // Only show operator-enabled languages that the user hasn't added yet
   const unusedCodes = SUPPORTED_TARGET_LANGUAGES.filter(
     (l) =>
-      (availableLanguageCodes.length === 0 ||
-        availableLanguageCodes.includes(l.code)) &&
+      availableLanguageCodes.includes(l.code) &&
       !addedCodes.includes(l.code)
   ).map((l) => l.code)
   const hasMultiple = userLanguages.length > 1

--- a/frontend/src/components/TargetLanguageSelector.tsx
+++ b/frontend/src/components/TargetLanguageSelector.tsx
@@ -22,13 +22,13 @@ export default function TargetLanguageSelector({
   )
 
   return (
-    <div className="flex gap-2">
+    <div className="grid grid-cols-2 gap-2">
       {filtered.map((lang) => (
         <button
           key={lang.code}
           type="button"
           onClick={() => onChange(lang.code)}
-          className={`flex flex-1 items-center justify-center gap-2 border px-3 py-3 font-mono text-xs tracking-widest uppercase transition-colors ${
+          className={`flex items-center gap-2 border px-3 py-3 font-mono text-xs tracking-widest uppercase transition-colors ${
             value === lang.code
               ? 'border-fl-accent bg-fl-accent text-fl-accent-fg'
               : 'border-fl-border text-fl-muted-2 hover:border-fl-border-2 hover:text-fl-fg'


### PR DESCRIPTION
This pull request updates the authentication and subscription checks for several backend API endpoints and makes minor UI improvements in the frontend. The most important changes are grouped below:

**Backend: Authentication and Subscription Checks**

* In `backend/app/routers/languages.py`, all language management endpoints now depend on `get_current_user` instead of `require_subscription`, removing the subscription check for these routes. [[1]](diffhunk://#diff-d606bfe9232631ca02ead2fabb09dbc8f856466a4914ce976591b8f4ffa3b386L7-R7) [[2]](diffhunk://#diff-d606bfe9232631ca02ead2fabb09dbc8f856466a4914ce976591b8f4ffa3b386L111-R111) [[3]](diffhunk://#diff-d606bfe9232631ca02ead2fabb09dbc8f856466a4914ce976591b8f4ffa3b386L141-R141) [[4]](diffhunk://#diff-d606bfe9232631ca02ead2fabb09dbc8f856466a4914ce976591b8f4ffa3b386L153-R153) [[5]](diffhunk://#diff-d606bfe9232631ca02ead2fabb09dbc8f856466a4914ce976591b8f4ffa3b386L163-R163) [[6]](diffhunk://#diff-d606bfe9232631ca02ead2fabb09dbc8f856466a4914ce976591b8f4ffa3b386L176-R176)
* In `backend/app/routers/listening.py` and `backend/app/routers/reading.py`, the `get_listening_history` and `get_reading_history` endpoints now require an active subscription by depending on `require_subscription` instead of just `get_current_user`. [[1]](diffhunk://#diff-c637c0299390d5946f473aa30168153ba6f286794ce89ef6241d0666748f8a5bL14-R14) [[2]](diffhunk://#diff-c637c0299390d5946f473aa30168153ba6f286794ce89ef6241d0666748f8a5bL270-R270) [[3]](diffhunk://#diff-625fe563c4feb3dd94c4475def11448e3b962870295e5b8ac719668585a4238aL11-R11) [[4]](diffhunk://#diff-625fe563c4feb3dd94c4475def11448e3b962870295e5b8ac719668585a4238aL219-R219)

**Frontend: UI Improvements**

* In `frontend/src/app/(app)/settings/languages/page.tsx`, the logic for displaying unused languages was simplified to only show languages that are both available and not yet added by the user.
* In `frontend/src/components/TargetLanguageSelector.tsx`, the layout of the language selector was changed from a horizontal flex row to a two-column grid, improving the appearance and usability of the language selection buttons.