### PR TITLE
feature: deploy to main

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -90,14 +90,14 @@ export default async function RootLayout({
             __html: `(function(){if(document.cookie.indexOf('LOCALE_DETECTED=')!==-1)return;var m=document.cookie.match(/(^| )NEXT_LOCALE=([^;]+)/);var cl=m?m[2]:null;var bl=(navigator.language||'').split('-')[0].toLowerCase();var s=['es','fr','pt','de','it','pl','nl','ro','ru'];document.cookie='LOCALE_DETECTED=1;path=/;max-age=31536000;SameSite=Lax';if(bl!=='en'&&s.indexOf(bl)!==-1&&cl!==bl){document.cookie='NEXT_LOCALE='+bl+';path=/;max-age=31536000;SameSite=Lax';location.reload()}})();`,
           }}
         />
-        {process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL &&
-          process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && (
-            <script
-              defer
-              src={process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL}
-              data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
-            />
-          )}
+        {process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && (
+          <script
+            defer
+            src="/umami/script.js"
+            data-host-url="/umami"
+            data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
+          />
+        )}
       </head>
       <body className="min-h-full bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
         <NextIntlClientProvider locale={locale} messages={messages}>

--- a/frontend/src/app/umami/api/[...path]/route.ts
+++ b/frontend/src/app/umami/api/[...path]/route.ts
@@ -1,0 +1,29 @@
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const scriptUrl = process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL
+  if (!scriptUrl) return new Response(null, { status: 404 })
+
+  const { path } = await params
+  const base = new URL(scriptUrl).origin
+  const url = `${base}/api/${path.join('/')}`
+
+  try {
+    const body = await req.text()
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': req.headers.get('Content-Type') ?? 'application/json',
+        'User-Agent': req.headers.get('User-Agent') ?? '',
+        'Accept-Language': req.headers.get('Accept-Language') ?? '*',
+      },
+      body,
+    })
+    return new Response(res.body, { status: res.status })
+  } catch {
+    return new Response(null, { status: 502 })
+  }
+}

--- a/frontend/src/app/umami/script.js/route.ts
+++ b/frontend/src/app/umami/script.js/route.ts
@@ -1,0 +1,20 @@
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const url = process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL
+  if (!url) return new Response('Umami not configured', { status: 404 })
+
+  try {
+    const res = await fetch(url)
+    if (!res.ok) return new Response(null, { status: res.status })
+    const body = await res.text()
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'application/javascript; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+      },
+    })
+  } catch {
+    return new Response(null, { status: 502 })
+  }
+}


### PR DESCRIPTION
This pull request updates how the Umami analytics script is loaded and proxied in the frontend application. The main change is to serve the Umami script and API requests through local proxy routes instead of loading them directly from the external Umami server. This improves privacy, makes analytics script delivery more robust, and simplifies configuration for deployments.

**Umami analytics integration improvements:**

* The Umami analytics script is now loaded from a local proxy route (`/umami/script.js`) instead of directly from the external URL, and the script tag uses new `src` and `data-host-url` attributes for local serving. (`frontend/src/app/layout.tsx`)
* Added a new route handler (`frontend/src/app/umami/script.js/route.ts`) that fetches the Umami script from the configured external URL and serves it locally, with appropriate caching headers. (`frontend/src/app/umami/script.js/route.ts`)
* Added a new API proxy route (`frontend/src/app/umami/api/[...path]/route.ts`) that forwards POST requests to the Umami analytics API endpoint, allowing all analytics API traffic to be proxied through the local server. (`frontend/src/app/umami/api/[...path]/route.ts`) ([frontend/src/app/umami/api/[...path]/route.tsR1-R29](diffhunk://#diff-60dca4204f492af5a9acc623ef1c98b94adb128755174ffef5f2440ffd07c3f8R1-R29))